### PR TITLE
Object.values fix + map fix on mobile Safari

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,5 +1,10 @@
 module.exports = {
   presets: [
-    '@vue/app',
+    [
+      "@vue/app",
+      {
+        useBuiltIns: "entry",
+      },
+    ],
   ],
 };

--- a/src/App.vue
+++ b/src/App.vue
@@ -164,8 +164,8 @@
       ></v-select>
     </v-toolbar>
     <v-content class="fixed">
-      <div id="map" style="width: 100%; height: 100%;"></div>
-      <div style="position: fixed; bottom: 0; width: 100%">
+      <div id="map" class="fixed"></div>
+      <div style="position: fixed; bottom: 0; width: 100%" >
         <v-card class="ma-2 elevation-0 d-inline-flex" v-if="showKeypadTimeout">
           <v-card-text class="keypadLabel d-inline">
             {{mouseKeypad}}

--- a/src/App.vue
+++ b/src/App.vue
@@ -164,7 +164,7 @@
       ></v-select>
     </v-toolbar>
     <v-content class="fixed">
-      <div id="map" class="fixed"></div>
+      <div id="map" :class="mapClass"></div>
       <div style="position: fixed; bottom: 0; width: 100%" >
         <v-card class="ma-2 elevation-0 d-inline-flex" v-if="showKeypadTimeout">
           <v-card-text class="keypadLabel d-inline">
@@ -257,7 +257,7 @@ export default {
       mortar: undefined, // active mortar (for line drawing)
       target: undefined, // active target (for line drawing)
       distLine: undefined, // the line
-
+      mapClass: undefined,
       // available colors
       mortarColors: ["/img/svg/mortar_pin_red.svg",
         "/img/svg/mortar_pin_green.svg", "/img/svg/mortar_pin_blue.svg", "/img/svg/mortar_pin.svg"],
@@ -300,6 +300,18 @@ export default {
       this.changeMap(this.selectedMap);
     }
     setTimeout(() => {
+      // dirty hack to set map position to fixed on mobile devices
+      // on mobile safari, map doesn't show if not fixed
+      // but if always fixed, persistent navbar is over map on desktop, which is clunky
+      // so this is the compromise.
+      if (!this.drawer) {
+        const style = document.getElementById("map").style;
+        style.position = "fixed";
+        style.left = "0";
+        style.right = "0";
+        style.top = "0";
+        style.bottom = "0";
+      }
       this.map.invalidateSize();
     }, 10);
   },
@@ -349,8 +361,8 @@ export default {
       const x = 256 / squadMap.bounds.getNorth(); // 256 is inital tile size
       const y = 256 / squadMap.bounds.getEast();
       this.map.options.crs.transformation = new Transformation(y, 0, x, 0);
-      this.map.fitBounds(squadMap.bounds.pad(0.1));
-      this.map.setMaxBounds(squadMap.bounds.pad(0.1));
+      this.map.fitBounds(squadMap.bounds);
+      this.map.setMaxBounds(squadMap.bounds.pad(0.5));
 
       console.log("setting up grid");
       this.grid.setBounds(squadMap.bounds);
@@ -784,6 +796,8 @@ export default {
   #map {
     cursor: crosshair;
     z-index: 0;
+    width: 100%;
+    height: 100%;
   }
 
   #heightmap {

--- a/src/main.js
+++ b/src/main.js
@@ -1,4 +1,4 @@
-// import "@babel/polyfill";
+import "@babel/polyfill";
 import Vue from "vue";
 import "./plugins/vuetify";
 import App from "./App.vue";


### PR DESCRIPTION
On some devices, like mobile Safari on ios9, the page would not load because of a missing polyfill for Object.values.

The vue-cli vuetify plugin should have adapted the babel.config.js, but didn't, so this issue popped up.

I manually added the addition to the config, so now the error doesn't show up.

However, I also found out that the map doesn't show up on mobile Safari, unless the map has position: fixed css property. But fixed is bad on desktop, so I added a hack that sets it to fixed only on mobile.