### PR TITLE
Postscriptum

### DIFF
--- a/src/Map.vue
+++ b/src/Map.vue
@@ -1117,6 +1117,7 @@ export default {
       }
       if (this.tTypeIndex === TARGET_TYPE.AREA) {
         this.aSubTargets = [];
+		this.currentSubTarget = 0;
         const interval = 3;
         const boundaries = this.getCoordsBoundaries();
         const latVariation = (boundaries.maxLat - boundaries.minLat) / (interval + 1);

--- a/src/Map.vue
+++ b/src/Map.vue
@@ -100,7 +100,7 @@
           <v-list-tile-sub-title>
             <v-slider v-model="secondaryRoundsSpacing" hide-details class="pa-0 pr-3"
               always-dirty style="padding-left: 10px!important;"
-                    step="1" min="0" max="3" :thumb-size="24" ticks :tick-labels="SUBTARGET_ROUND_SPACING">
+                    step="1" min="0" max="4" :thumb-size="24" ticks :tick-labels="SUBTARGET_ROUND_SPACING">
             </v-slider>
           </v-list-tile-sub-title>
           </v-list-tile-content>

--- a/src/Map.vue
+++ b/src/Map.vue
@@ -1652,8 +1652,14 @@ export default {
           this.secondaryTarget = marker;
         }
       });
-      this.drawSecondaryLine();
-      this.calcSubTargets();
+      if (newIndex === TARGET_TYPE.POINT) {
+        this.removeSubTargets();
+        this.clearSecondaryLines();
+        this.secondaryTarget = undefined;
+      } else {
+        this.drawSecondaryLine();
+        this.calcSubTargets();
+      }
     },
 
     currentSubTarget(index) {

--- a/src/Map.vue
+++ b/src/Map.vue
@@ -374,7 +374,8 @@
         v-if="mortar && target && tTypeIndex > TARGET_TYPE.POINT && secondaryTarget"
         style="background-color: #212121">
         <v-speed-dial>
-          <v-btn fab small slot="activator" class="secondary" style="width: 32px; height: 32px;">
+          <v-btn fab small slot="activator" class="secondary"
+            style="width: 32px; height: 32px; margin-left: 4px; margin-right: 4px;">
             <img :src="mortar.sUrl" style="width: 48px;">
           </v-btn>
           <v-btn icon
@@ -385,9 +386,10 @@
             <img :src="aMortar.sUrl" style="width: 48px;">
           </v-btn>
         </v-speed-dial>
-        <v-icon>arrow_forward</v-icon>
+        <v-icon style="font-size: 16px;">arrow_forward</v-icon>
         <v-speed-dial v-if="target">
-          <v-btn fab small slot="activator" class="secondary" style="width: 32px; height: 32px;">
+          <v-btn fab small slot="activator" class="secondary"
+            style="width: 32px; height: 32px; margin-left: 4px; margin-right: 4px;">
             <img :src="target.sUrl" style="width: 48px;">
           </v-btn>
           <v-btn icon
@@ -398,9 +400,9 @@
             <img :src="aTarget.sUrl" style="width: 48px;">
           </v-btn>
         </v-speed-dial>
-        <v-icon v-if="tTypeIndex > TARGET_TYPE.POINT && secondaryTarget">arrow_forward</v-icon>
         <v-speed-dial v-if="tTypeIndex > TARGET_TYPE.POINT && secondaryTarget">
-          <v-btn fab small slot="activator" class="secondary" style="width: 32px; height: 32px;">
+          <v-btn fab small slot="activator" class="secondary"
+            style="width: 32px; height: 32px; margin-left: 4px; margin-right: 4px;">
             <img :src="secondaryTarget.sUrl" style="width: 48px;">
           </v-btn>
           <v-btn icon
@@ -411,43 +413,28 @@
             <img :src="aTarget.sUrl" style="width: 48px;">
           </v-btn>
         </v-speed-dial>
-        <div class="font-mono flex column"
-          v-if="tTypeIndex <= 0 || (tTypeIndex > TARGET_TYPE.POINT && secondaryTarget === undefined)">
+        <div class="font-mono flex column">
           <div class="flex" style="width: 100%;">
-            <div class="px-1" style="flex: 1 0 auto; text-align: center; font-size: large">
-            {{DOMbearing}}
-            </div>
-            <div class="px-1" style="flex: 1 0 auto; text-align: center; font-size: large">
-            {{DOMelevation}}
-            </div>
-          </div>
-          <div class="flex" style="width: 100%;">
-            <div class="px-1 body-1" style="flex: 1 0 auto; text-align: center; font-size: small; color: #9e9e9e"
-            >{{DOMdist}}</div>
-            <div class="px-1 body-1" style="flex: 1 0 auto; text-align: center; font-size: small; color: #9e9e9e"
-            >{{DOMhDelta}}</div>
-          </div>
-        </div>
-        <div class="font-mono flex column" v-if="tTypeIndex > TARGET_TYPE.POINT && secondaryTarget">
-          <div class="flex" style="width: 100%;">
-            <div class="px-1" style="flex: 1 0 auto; text-align: center; font-size: large">
+            <div class="px-1" style="flex: 1 0 auto; font-size: small; padding-left: 0!important;">
             {{DOMminbearing}}
             </div>
-            <v-icon>arrow_forward</v-icon>
-            <div class="px-1" style="flex: 1 0 auto; text-align: center; font-size: large">
+            <v-icon style="font-size: small">arrow_forward</v-icon>
+            <div class="px-1" style="flex: 1 0 auto; font-size: small; padding-left: 0!important;">
             {{DOMmaxbearing}}
             </div>
           </div>
           <div class="flex" style="width: 100%;">
-            <div class="px-1" style="flex: 1 0 auto; text-align: center; font-size: large">
+            <div class="px-1" style="flex: 1 0 auto; font-size: small; padding-left: 0!important;">
             {{DOMminelevation}}
             </div>
-            <v-icon>arrow_forward</v-icon>
-            <div class="px-1" style="flex: 1 0 auto; text-align: center; font-size: large">
+            <v-icon style="font-size: small">arrow_forward</v-icon>
+            <div class="px-1" style="flex: 1 0 auto; font-size: small; padding-left: 0!important;">
             {{DOMmaxelevation}}
             </div>
           </div>
         </div>
+      </div>
+      <div class="flex" style="flex;background-color: #212121">
         <div class="font-mono flex column"
           v-if="tTypeIndex > TARGET_TYPE.POINT && secondaryTarget" v-for="(aShot, index) in aShots" :key="index">
           <div class="flex" style="width: 100%;">

--- a/src/Map.vue
+++ b/src/Map.vue
@@ -1265,8 +1265,8 @@ export default {
               this.addSubtarget(coords[0][0]);
               this.addSubtarget(coords[0][1]);
               this.addSubtarget(coords[0][2]);
-              this.addSubtarget(coords[2][2]);
-              this.addSubtarget(coords[2][2]);
+              this.addSubtarget(coords[2][0]);
+              this.addSubtarget(coords[2][1]);
               this.addSubtarget(coords[2][2]);
             }
             break;

--- a/src/Map.vue
+++ b/src/Map.vue
@@ -1289,7 +1289,7 @@ export default {
             }
             break;
           case 7:
-            if (random <= 50) {
+            if (random <= 25) {
               this.addSubtarget(coords[0][0]);
               this.addSubtarget(coords[1][0]);
               this.addSubtarget(coords[2][0]);
@@ -1297,7 +1297,7 @@ export default {
               this.addSubtarget(coords[1][2]);
               this.addSubtarget(coords[2][2]);
               this.addSubtarget(coords[1][1]);
-            } else if (random <= 100) {
+            } else if (random <= 50) {
               this.addSubtarget(coords[0][0]);
               this.addSubtarget(coords[0][1]);
               this.addSubtarget(coords[0][2]);
@@ -1305,6 +1305,22 @@ export default {
               this.addSubtarget(coords[2][1]);
               this.addSubtarget(coords[2][2]);
               this.addSubtarget(coords[1][1]);
+            } else if (random <= 75) {
+              this.addSubtarget(coords[0][0]);
+              this.addSubtarget(coords[1][0]);
+              this.addSubtarget(coords[0][1]);
+              this.addSubtarget(coords[1][1]);
+              this.addSubtarget(coords[2][1]);
+              this.addSubtarget(coords[1][2]);
+              this.addSubtarget(coords[2][2]);
+            } else if (random <= 100) {
+              this.addSubtarget(coords[2][0]);
+              this.addSubtarget(coords[1][0]);
+              this.addSubtarget(coords[0][1]);
+              this.addSubtarget(coords[1][1]);
+              this.addSubtarget(coords[2][1]);
+              this.addSubtarget(coords[1][2]);
+              this.addSubtarget(coords[0][2]);
             }
             break;
           case 8:

--- a/src/Map.vue
+++ b/src/Map.vue
@@ -552,7 +552,7 @@ import {
   PS_4INCH_MAX_DISTANCE,
   PS_4INCH_VELOCITY,
   PS_8CM_MAX_DISTANCE,
-  PS_8CM_VELOCITY, SQUAD_MAX_DISTANCE, SQUAD_VELOCITY,
+  PS_8CM_VELOCITY, SQUAD_MAX_DISTANCE, SQUAD_VELOCITY, SUBTARGET_RADIUS,
 } from "./assets/Vars";
 import PinHolder from "./assets/PinHolder";
 import MapData from "./assets/MapData";
@@ -640,6 +640,7 @@ export default {
         dist: undefined,
         hDelta: undefined,
       },
+      SUBTARGET_RADIUS, // subtarget radius for map zoom
       TARGET_TYPE, // reference to target types
       PIN_TYPE, // reference to pin types
       pad, // reference to padding function used for formatting distance, heightDiff, etc.
@@ -728,6 +729,7 @@ export default {
 
       this.map.on("mousemove", this.onMouseMove, this);
       this.map.on("click", this.onMapClick, this);
+      this.map.on("zoomend", this.onZoomEnd, this);
     },
 
     /**
@@ -806,6 +808,12 @@ export default {
       this.map._resetView(this.map.getCenter(), this.map.getZoom());
 
       this.squadMap = squadMap;
+    },
+    onZoomEnd() {
+      this.aSubTargets.forEach((subTarget) => {
+        subTarget.mapLayer.setRadius(SUBTARGET_RADIUS[this.map.getZoom()]);
+      });
+      console.log("onZoomEnd:", this.map.getZoom());
     },
     /**
      * Handles "mousemove" events on leaflet map
@@ -1113,7 +1121,7 @@ export default {
           fillColor: color,
           weight: 3,
           fillOpacity: 1,
-          radius: 3,
+          radius: SUBTARGET_RADIUS[this.map.getZoom()],
           bubblingMouseEvents: false,
           subTargetIndex, // additionnal options in order to handle easily click event
           app: this, // additionnal options in order to handle easily click event

--- a/src/Map.vue
+++ b/src/Map.vue
@@ -327,7 +327,52 @@
           </v-dialog>
         </div>
       </div>
-      <div id="my-footer" v-if="mortar && target" style="background-color: #212121">
+      <div id="my-footer" v-if="mortar && target && secondaryTarget == undefined" style="background-color: #212121">
+        <v-speed-dial>
+          <v-btn fab small slot="activator" class="secondary" style="width: 32px; height: 32px;">
+            <img :src="mortar.sUrl" style="width: 48px;">
+          </v-btn>
+          <v-btn icon
+                 v-for="(aMortar, index) in placedMortars"
+                 :key="index"
+                 @click="mortar = placedMortars[index]"
+          >
+            <img :src="aMortar.sUrl" style="width: 48px;">
+          </v-btn>
+        </v-speed-dial>
+        <v-icon>arrow_forward</v-icon>
+        <v-speed-dial v-if="target">
+          <v-btn fab small slot="activator" class="secondary" style="width: 32px; height: 32px;">
+            <img :src="target.sUrl" style="width: 48px;">
+          </v-btn>
+          <v-btn icon
+                 v-for="(aTarget, index) in placedTargets"
+                 :key="index"
+                 v-if="secondaryTarget !== undefined && aTarget.sUrl != secondaryTarget.sUrl"
+                 @click="target = placedTargets[index]">
+            <img :src="aTarget.sUrl" style="width: 48px;">
+          </v-btn>
+        </v-speed-dial>
+        <div class="font-mono flex column">
+          <div class="flex" style="width: 100%;">
+            <div class="px-1" style="flex: 1 0 auto; text-align: center; font-size: large">
+            {{DOMbearing}}
+            </div>
+            <div class="px-1" style="flex: 1 0 auto; text-align: center; font-size: large">
+            {{DOMelevation}}
+            </div>
+          </div>
+          <div class="flex" style="width: 100%;">
+            <div class="px-1 body-1" style="flex: 1 0 auto; text-align: center; font-size: small; color: #9e9e9e"
+            >{{DOMdist}}</div>
+            <div class="px-1 body-1" style="flex: 1 0 auto; text-align: center; font-size: small; color: #9e9e9e"
+            >{{DOMhDelta}}</div>
+          </div>
+        </div>
+      </div>
+      <div id="my-footer"
+        v-if="mortar && target && tTypeIndex > TARGET_TYPE.POINT && secondaryTarget"
+        style="background-color: #212121">
         <v-speed-dial>
           <v-btn fab small slot="activator" class="secondary" style="width: 32px; height: 32px;">
             <img :src="mortar.sUrl" style="width: 48px;">
@@ -478,6 +523,7 @@
   <v-dialog v-model="changelogDialog" max-width="600px">
     <v-card>
       <v-card-text>
+        <Changelog/>
         <Changelog/>
       </v-card-text>
       <v-card-actions>
@@ -867,7 +913,7 @@ export default {
           for (let i = 0; i < this.placedTargets.length; i += 1) {
             if (this.colors.pin.target[urlIndex] === this.placedTargets[i].pUrl) {
               this.placedTargets[i].pos = pos;
-              if (this.placedTargets[i].pUrl === this.secondaryTarget.pUrl) {
+              if (this.secondaryTarget !== undefined && this.placedTargets[i].pUrl === this.secondaryTarget.pUrl) {
                 this.secondaryTarget = this.placedTargets[i];
               } else {
                 this.target = this.placedTargets[i];
@@ -1246,11 +1292,16 @@ export default {
           this.target = this.placedTargets[i === 0 ? 0 : i - 1];
           if (this.target.pUrl === this.secondaryTarget.pUrl) {
             this.secondaryTarget = undefined;
+            this.drawSecondaryLine();
           }
         } else {
           this.target = undefined;
           this.secondaryTarget = undefined;
+          this.drawSecondaryLine();
         }
+      } else if (tTarget === this.secondaryTarget) {
+        this.secondaryTarget = undefined;
+        this.drawSecondaryLine();
       }
       tTarget.removeFrom(this.map);
     },

--- a/src/Map.vue
+++ b/src/Map.vue
@@ -435,7 +435,10 @@
         </div>
       </div>
       <div id="my-subtargets" class="flex" style="flex;background-color: #212121; align-items: center;"
-        v-if="aSubTargets.length > 0">
+        v-if="aSubTargets.length > 0" v-touch="{
+          left: () => onSwipe('Left'),
+          right: () => onSwipe('Right')
+        }">
         <div class="flex" v-if="currentSubTarget > 0">
           <v-icon @click="currentSubTarget--">keyboard_arrow_left</v-icon>
         </div>
@@ -808,6 +811,21 @@ export default {
       this.map._resetView(this.map.getCenter(), this.map.getZoom());
 
       this.squadMap = squadMap;
+    },
+    onSwipe(direction) {
+      console.debug("onSwipe", direction);
+      switch (direction) {
+        case ("Right"):
+          this.currentSubTarget =
+            this.currentSubTarget > 0 ? this.currentSubTarget - 1 : this.currentSubTarget;
+          break;
+        case ("Left"):
+          this.currentSubTarget =
+            this.currentSubTarget < this.aSubTargets.length ? this.currentSubTarget + 1 : this.currentSubTarget;
+          break;
+        default:
+          break;
+      }
     },
     onZoomEnd() {
       this.aSubTargets.forEach((subTarget) => {

--- a/src/Map.vue
+++ b/src/Map.vue
@@ -94,7 +94,7 @@
             </v-btn-toggle></v-list-tile-sub-title>
         </v-list-tile-content>
       </v-list-tile>
-	  <v-list-tile>
+	   <v-list-tile v-if="tTypeIndex > TARGET_TYPE.POINT">
           <div class="pr-3">Rounds</div>
           <v-slider v-model="secondaryShots" hide-details thumb-label class="pa-0 pr-3"
                     step="1" min="3" max="9" ticks></v-slider>

--- a/src/Map.vue
+++ b/src/Map.vue
@@ -97,7 +97,7 @@
 	   <v-list-tile v-if="tTypeIndex > TARGET_TYPE.POINT">
           <div class="pr-3">Rounds</div>
           <v-slider v-model="secondaryShots" hide-details thumb-label class="pa-0 pr-3"
-                    step="1" min="3" max="9" ticks></v-slider>
+                    step="1" min="3" max="9" thumb-label="always" :thumb-size="24" ticks></v-slider>
         </v-list-tile>
     </v-list>
     <v-divider v-if="postScriptum"></v-divider>

--- a/src/Map.vue
+++ b/src/Map.vue
@@ -1069,11 +1069,11 @@ export default {
       if (delayUpdate) {
         this.calcTimeout = setTimeout(() => {
           this.c2 = newC;
-          this.calcShots();
+          this.calcSubTargets();
         }, 250);
       } else {
         this.c2 = newC;
-        this.calcShots();
+        this.calcSubTargets();
       }
     },
     getCoordsBoundaries() {
@@ -1109,8 +1109,11 @@ export default {
           DOMElevation: this.formatDOMElevation(coords.elevation),
         },
         mapLayer: new Circle(pos, {
-          color,
+          color: subTargetIndex === this.currentSubTarget ? "#3333ff" : color,
+          fillColor: color,
+          weight: 3,
           fillOpacity: 1,
+          radius: 3,
           bubblingMouseEvents: false,
           subTargetIndex, // additionnal options in order to handle easily click event
           app: this, // additionnal options in order to handle easily click event
@@ -1126,7 +1129,7 @@ export default {
       console.log("click on subTarget", e.target.options.subTargetIndex);
       e.target.options.app.currentSubTarget = e.target.options.subTargetIndex;
     },
-    calcShots() {
+    calcSubTargets() {
       this.removeSubTargets();
       if (this.tTypeIndex === TARGET_TYPE.LINE) {
         const interval = this.secondaryShots - 2;
@@ -1160,7 +1163,7 @@ export default {
           bearing: this.c2.bearing,
           elevation: this.c2.elevation,
         });// Last shot is fixed
-        console.log("calcShots", this.shots);
+        console.log("calcSubTargets", this.aSubTargets);
       }
       if (this.tTypeIndex === TARGET_TYPE.AREA) {
         const interval = 3;
@@ -1601,7 +1604,7 @@ export default {
     secondaryShots(i) {
       this.toStorage("secondaryShots", i);
       if (this.advancedMode && this.target && this.secondaryTarget && this.tTypeIndex > TARGET_TYPE.POINT) {
-        this.calcShots();
+        this.calcSubTargets();
       }
     },
     /**
@@ -1684,8 +1687,20 @@ export default {
       this.drawSecondaryLine();
     },
 
-    currentSubTarget(i) {
-      this.toStorage("currentSubTarget", i);
+    currentSubTarget(index) {
+      let color = NaN;
+      console.log("Selected subTarget", this.aSubTargets[index]);
+      for (let i = 0; i < this.aSubTargets.length; i++) { // reset all subtargets colors
+        color = Number.isNaN(this.aSubTargets[i].coords.elevation)
+          || this.aSubTargets[i].coords.elevation > 1580
+          || this.aSubTargets[i].coords.elevation < 800 ? "#f44336" : "#4caf50";
+        this.aSubTargets[i].mapLayer.setStyle({
+          color: i === index ? "#3333ff" : color, // except currently selected subtarget
+          fillColor: color,
+        });
+      }
+
+      this.toStorage("currentSubTarget", index);
     },
 
     /* PostScriptum exclusive */

--- a/src/Map.vue
+++ b/src/Map.vue
@@ -96,7 +96,7 @@
       </v-list-tile>
        <v-list-tile v-if="tTypeIndex > TARGET_TYPE.POINT">
           <div class="pr-3">Rounds</div>
-          <v-slider v-model="secondaryShots" hide-details thumb-label class="pa-0 pr-3"
+          <v-slider v-model="secondaryShots" hide-details class="pa-0 pr-3"
                     step="1" min="3" max="9" thumb-label="always" :thumb-size="24" ticks></v-slider>
         </v-list-tile>
     </v-list>
@@ -366,7 +366,8 @@
             <img :src="aTarget.sUrl" style="width: 48px;">
           </v-btn>
         </v-speed-dial>
-        <div class="font-mono flex column" v-if="tTypeIndex <= 0 || (tTypeIndex > TARGET_TYPE.POINT && secondaryTarget === undefined)">
+        <div class="font-mono flex column"
+          v-if="tTypeIndex <= 0 || (tTypeIndex > TARGET_TYPE.POINT && secondaryTarget === undefined)">
           <div class="flex" style="width: 100%;">
             <div class="px-1" style="flex: 1 0 auto; text-align: center; font-size: large">
             {{DOMbearing}}
@@ -402,7 +403,8 @@
             </div>
           </div>
         </div>
-        <div class="font-mono flex column" v-if="tTypeIndex > TARGET_TYPE.POINT && secondaryTarget" v-for="(aShot, index) in aShots">
+        <div class="font-mono flex column"
+          v-if="tTypeIndex > TARGET_TYPE.POINT && secondaryTarget" v-for="(aShot, index) in aShots" :key="index">
           <div class="flex" style="width: 100%;">
             <div class="px-1" style="flex: 1 0 auto; text-align: center; font-size: small">
                 Round {{index + 1}}
@@ -558,7 +560,7 @@ export default {
       secondaryTarget: undefined, // secondary target (for line and area target type)
       secondaryShots: Number.parseInt(this.fromStorage("secondaryShots", "5"), 10),
       distLine: undefined, // the line
-      secondaryLine: undefined,// The secondary line
+      secondaryLine: undefined, // The secondary line
       aShots: [], // values of intermediary shots (for line and area target)
       // available colors
       colors: {
@@ -622,7 +624,7 @@ export default {
       targetTypes: [
         "POINT",
         "LINE",
-        "AREA"
+        "AREA",
       ],
       tTypeIndex: Number.parseInt(this.fromStorage("tTypeIndex", "0"), 10),
 
@@ -865,10 +867,11 @@ export default {
           for (let i = 0; i < this.placedTargets.length; i += 1) {
             if (this.colors.pin.target[urlIndex] === this.placedTargets[i].pUrl) {
               this.placedTargets[i].pos = pos;
-              if (this.placedTargets[i].pUrl == this.secondaryTarget.pUrl)
+              if (this.placedTargets[i].pUrl === this.secondaryTarget.pUrl) {
                 this.secondaryTarget = this.placedTargets[i];
-              else
+              } else {
                 this.target = this.placedTargets[i];
+              }
               return;
             }
           }
@@ -876,9 +879,9 @@ export default {
           this.placedTargets.push(pin);
           if (this.tTypeIndex > TARGET_TYPE.POINT && this.target !== undefined) {
             this.secondaryTarget = pin;
-          }
-          else
+          } else {
             this.target = pin;
+          }
           break;
         case PIN_TYPE.FOB:
           for (let i = 0; i < this.placedFobs.length; i += 1) {
@@ -904,41 +907,38 @@ export default {
       }
     },
     drawSecondaryLine() {
-        console.log("drawSecondaryLines()");
-        this.clearSecondaryLines();
-        if (this.advancedMode && this.target && this.secondaryTarget)
-        {
-            if (this.tTypeIndex === TARGET_TYPE.LINE)//Line target type
-            {
-                const line = new Polyline([this.target.pos, this.secondaryTarget.pos], {
-                  color: "#3333ff",
-                  interactive: false,
-                  clickable: false, // legacy support
-                });
-                if (!this.map.hasLayer(line)) {
-                    this.secondaryLine = line;
-                    this.map.addLayer(line);
-                }
-            }
-            if (this.tTypeIndex == TARGET_TYPE.AREA)//Area target type
-            {
-                const rectangle = new Rectangle([
-                                                    [this.target.pos.lat, this.target.pos.lng],
-                                                    [this.secondaryTarget.pos.lat, this.secondaryTarget.pos.lng]
-                                                ],
-                                                {color:"#3333ff", weight: 1});
-                if (!this.map.hasLayer(rectangle)) {
-                    this.secondaryLine = rectangle;
-                    this.map.addLayer(rectangle);
-                }
-            }
+      console.log("drawSecondaryLines()");
+      this.clearSecondaryLines();
+      if (this.advancedMode && this.target && this.secondaryTarget) {
+        if (this.tTypeIndex === TARGET_TYPE.LINE) { // Line target type
+          const line = new Polyline([this.target.pos, this.secondaryTarget.pos], {
+            color: "#3333ff",
+            interactive: false,
+            clickable: false, // legacy support
+          });
+          if (!this.map.hasLayer(line)) {
+            this.secondaryLine = line;
+            this.map.addLayer(line);
+          }
         }
+        if (this.tTypeIndex === TARGET_TYPE.AREA) { // Area target type
+          const rectangle = new Rectangle(
+            [
+              [this.target.pos.lat, this.target.pos.lng],
+              [this.secondaryTarget.pos.lat, this.secondaryTarget.pos.lng],
+            ],
+            { color: "#3333ff", weight: 1 },
+          );
+          if (!this.map.hasLayer(rectangle)) {
+            this.secondaryLine = rectangle;
+            this.map.addLayer(rectangle);
+          }
+        }
+      }
     },
     coordMortar(mortar, target) {
       const s = mortar.pos;
       const e = target.pos;
-
-      const coords = {};
 
       // oh no, vector maths!
       let bearing = Math.atan2(e.lng - s.lng, e.lat - s.lat) * 180 / Math.PI;
@@ -1005,8 +1005,6 @@ export default {
         this.map.addLayer(this.distLine);
       }
 
-
-
       if (this.calcTimeout) { clearTimeout(this.calcTimeout); }
 
       // if we want to delay the calc update, we set a timer that will set this.c
@@ -1036,199 +1034,186 @@ export default {
         this.c2 = newC;
         this.calcShots();
       }
-
     },
     getCoordsBoundaries() {
-        return {
-            minLat: this.target.pos.lat <= this.secondaryTarget.pos.lat ? this.target.pos.lat : this.secondaryTarget.pos.lat,
-            maxLat: this.target.pos.lat > this.secondaryTarget.pos.lat ? this.target.pos.lat : this.secondaryTarget.pos.lat,
-            minLng: this.target.pos.lng <= this.secondaryTarget.pos.lng ? this.target.pos.lng : this.secondaryTarget.pos.lng,
-            maxLng: this.target.pos.lng > this.secondaryTarget.pos.lng ? this.target.pos.lng : this.secondaryTarget.pos.lng,
-        };
+      const s = this.target.pos;
+      const e = this.secondaryTarget.pos;
+      return {
+        minLat: s.lat <= e.lat ? s.lat : e.lat,
+        maxLat: s.lat > e.lat ? s.lat : e.lat,
+        minLng: s.lng <= e.lng ? s.lng : e.lng,
+        maxLng: s.lng > e.lng ? s.lng : e.lng,
+      };
     },
     calcShots() {
-        if (this.tTypeIndex == TARGET_TYPE.LINE)
-        {
-            const interval = this.secondaryShots - 2;
-            const boundaries = this.getCoordsBoundaries();
-            const latVariation = (boundaries.maxLat - boundaries.minLat) / (interval + 1);
-            const lngVariation = (boundaries.maxLng - boundaries.minLng) / (interval + 1);
+      if (this.tTypeIndex === TARGET_TYPE.LINE) {
+        const interval = this.secondaryShots - 2;
+        const boundaries = this.getCoordsBoundaries();
+        const latVariation = (boundaries.maxLat - boundaries.minLat) / (interval + 1);
+        const lngVariation = (boundaries.maxLng - boundaries.minLng) / (interval + 1);
 
-            this.aShots = [];
-            this.aShots.push({
-                bearing: this.formatDOMBearing(this.c.bearing),
-                elevation: this.formatDOMElevation(this.c.elevation)
-            });//First shot is fixed
+        this.aShots = [];
+        this.aShots.push({
+          bearing: this.formatDOMBearing(this.c.bearing),
+          elevation: this.formatDOMElevation(this.c.elevation),
+        });// First shot is fixed
 
-            const point = {};
-            let coord;
-            for (let i = 1; i <= interval; i++)//Interval shots are computed
-            {
-                point.pos = new LatLng(boundaries.minLat + (latVariation * i), boundaries.minLng + (lngVariation * i), );
-                coord = this.coordMortar(this.mortar, point);
-                this.aShots.push({
-                    bearing: this.formatDOMBearing(coord.bearing),
-                    elevation: this.formatDOMElevation(coord.elevation)
-                });
-            }
-
-            this.aShots.push({
-                bearing: this.formatDOMBearing(this.c2.bearing),
-                elevation: this.formatDOMElevation(this.c2.elevation)
-            });//Last shot is fixed
-            console.log("calcShots", this.shots);
+        const point = {};
+        let coord;
+        for (let i = 1; i <= interval; i++) { // Interval shots are computed
+          point.pos = new LatLng(boundaries.minLat + (latVariation * i), boundaries.minLng + (lngVariation * i));
+          coord = this.coordMortar(this.mortar, point);
+          this.aShots.push({
+            bearing: this.formatDOMBearing(coord.bearing),
+            elevation: this.formatDOMElevation(coord.elevation),
+          });
         }
-        if (this.tTypeIndex == TARGET_TYPE.AREA)
-        {
-            this.aShots = [];
-            const interval = 3;
-            const boundaries = this.getCoordsBoundaries();
-            const latVariation = (boundaries.maxLat - boundaries.minLat) / (interval + 1);
-            const lngVariation = (boundaries.maxLng - boundaries.minLng) / (interval + 1);
 
-            const latitudes = [];
-            const longitudes = [];
-            for (let i = 1; i <= interval; i++)
-            {
-                latitudes.push(boundaries.minLat + (latVariation * i));
-                longitudes.push(boundaries.minLng + (lngVariation * i));
-            }
-            const coords = [];
-            const point = {};
-            let coord;
-            for (let i = 0; i < interval; i++)
-            {
-                for (let j = 0; j < interval; j++)
-                {
-                    point.pos = new LatLng(latitudes[i], longitudes[j]);
-                    coord = this.coordMortar(this.mortar, point);
-                    if (coords[i] === undefined)
-                        coords[i] = [];
-                    coords[i][j] = {
-                        bearing: this.formatDOMBearing(coord.bearing),
-                        elevation: this.formatDOMElevation(coord.elevation)
-                    };
-                }
-            }
-            const random = Math.floor(Math.random() * Math.floor(100));// get random value between 0-100
-            switch (this.secondaryShots){//will choose a random pattern on the 9 points available depends of the numbers of points wanted
-                case 3:
-                    if (random <= 25)
-                    {
-                        this.aShots.push(coords[0][0]);
-                        this.aShots.push(coords[1][1]);
-                        this.aShots.push(coords[2][2]);
-                    }
-                    else if (random <= 50)
-                    {
-                        this.aShots.push(coords[0][2]);
-                        this.aShots.push(coords[1][1]);
-                        this.aShots.push(coords[2][0]);
-                    }
-                    else if (random <= 75)
-                    {
-                        this.aShots.push(coords[1][0]);
-                        this.aShots.push(coords[1][1]);
-                        this.aShots.push(coords[1][2]);
-                    }
-                    else if (random <= 100)
-                    {
-                        this.aShots.push(coords[0][1]);
-                        this.aShots.push(coords[1][1]);
-                        this.aShots.push(coords[2][1]);
-                    }
-                    break;
-                case 4:
-                    if (random <= 50) {
-                        this.aShots.push(coords[0][0]);
-                        this.aShots.push(coords[2][0]);
-                        this.aShots.push(coords[0][2]);
-                        this.aShots.push(coords[2][2]);
-                    }
-                    else if (random <= 100){
-                        this.aShots.push(coords[1][0]);
-                        this.aShots.push(coords[0][1]);
-                        this.aShots.push(coords[2][1]);
-                        this.aShots.push(coords[1][2]);
-                    }
-                    break;
-                case 5:
-                    if (random <= 50) {
-                        this.aShots.push(coords[0][0]);
-                        this.aShots.push(coords[2][0]);
-                        this.aShots.push(coords[0][2]);
-                        this.aShots.push(coords[2][2]);
-                        this.aShots.push(coords[1][1]);
-                    }
-                    else if (random <= 100){
-                        this.aShots.push(coords[1][0]);
-                        this.aShots.push(coords[0][1]);
-                        this.aShots.push(coords[2][1]);
-                        this.aShots.push(coords[1][2]);
-                        this.aShots.push(coords[1][1]);
-                    }
-                    break;
-                case 6:
-                    if (random <= 50) {
-                        this.aShots.push(coords[0][0]);
-                        this.aShots.push(coords[1][0]);
-                        this.aShots.push(coords[2][0]);
-                        this.aShots.push(coords[0][2]);
-                        this.aShots.push(coords[1][2]);
-                        this.aShots.push(coords[2][2]);
-                    }
-                    else if (random <= 100){
-                        this.aShots.push(coords[0][0]);
-                        this.aShots.push(coords[0][1]);
-                        this.aShots.push(coords[0][2]);
-                        this.aShots.push(coords[2][2]);
-                        this.aShots.push(coords[2][2]);
-                        this.aShots.push(coords[2][2]);
-                    }
-                    break;
-                case 7:
-                    if (random <= 50) {
-                        this.aShots.push(coords[0][0]);
-                        this.aShots.push(coords[1][0]);
-                        this.aShots.push(coords[2][0]);
-                        this.aShots.push(coords[0][2]);
-                        this.aShots.push(coords[1][2]);
-                        this.aShots.push(coords[2][2]);
-                        this.aShots.push(coords[1][1]);
-                    }
-                    else if (random <= 100){
-                        this.aShots.push(coords[0][0]);
-                        this.aShots.push(coords[0][1]);
-                        this.aShots.push(coords[0][2]);
-                        this.aShots.push(coords[2][0]);
-                        this.aShots.push(coords[2][1]);
-                        this.aShots.push(coords[2][2]);
-                        this.aShots.push(coords[1][1]);
-                    }
-                    break;
-                case 8:
-                    this.aShots.push(coords[0][0]);
-                    this.aShots.push(coords[0][1]);
-                    this.aShots.push(coords[0][2]);
-                    this.aShots.push(coords[1][0]);
-                    this.aShots.push(coords[1][2]);
-                    this.aShots.push(coords[2][0]);
-                    this.aShots.push(coords[2][1]);
-                    this.aShots.push(coords[2][2]);
-                    break;
-                case 9:
-                    this.aShots.push(coords[0][0]);
-                    this.aShots.push(coords[0][1]);
-                    this.aShots.push(coords[0][2]);
-                    this.aShots.push(coords[1][0]);
-                    this.aShots.push(coords[1][1]);
-                    this.aShots.push(coords[1][2]);
-                    this.aShots.push(coords[2][0]);
-                    this.aShots.push(coords[2][1]);
-                    this.aShots.push(coords[2][2]);
-                    break;
-            }
+        this.aShots.push({
+          bearing: this.formatDOMBearing(this.c2.bearing),
+          elevation: this.formatDOMElevation(this.c2.elevation),
+        });// Last shot is fixed
+        console.log("calcShots", this.shots);
+      }
+      if (this.tTypeIndex === TARGET_TYPE.AREA) {
+        this.aShots = [];
+        const interval = 3;
+        const boundaries = this.getCoordsBoundaries();
+        const latVariation = (boundaries.maxLat - boundaries.minLat) / (interval + 1);
+        const lngVariation = (boundaries.maxLng - boundaries.minLng) / (interval + 1);
+
+        const latitudes = [];
+        const longitudes = [];
+        for (let i = 1; i <= interval; i++) {
+          latitudes.push(boundaries.minLat + (latVariation * i));
+          longitudes.push(boundaries.minLng + (lngVariation * i));
         }
+        const coords = [];
+        const point = {};
+        let coord;
+        for (let i = 0; i < interval; i++) {
+          for (let j = 0; j < interval; j++) {
+            point.pos = new LatLng(latitudes[i], longitudes[j]);
+            coord = this.coordMortar(this.mortar, point);
+            if (coords[i] === undefined) {
+              coords[i] = [];
+            }
+            coords[i][j] = {
+              bearing: this.formatDOMBearing(coord.bearing),
+              elevation: this.formatDOMElevation(coord.elevation),
+            };
+          }
+        }
+        const random = Math.floor(Math.random() * Math.floor(100));// get random value between 0-100
+        // will choose a random pattern on the 9 points available depends of the numbers of points wanted
+        switch (this.secondaryShots) {
+          case 3:
+            if (random <= 25) {
+              this.aShots.push(coords[0][0]);
+              this.aShots.push(coords[1][1]);
+              this.aShots.push(coords[2][2]);
+            } else if (random <= 50) {
+              this.aShots.push(coords[0][2]);
+              this.aShots.push(coords[1][1]);
+              this.aShots.push(coords[2][0]);
+            } else if (random <= 75) {
+              this.aShots.push(coords[1][0]);
+              this.aShots.push(coords[1][1]);
+              this.aShots.push(coords[1][2]);
+            } else if (random <= 100) {
+              this.aShots.push(coords[0][1]);
+              this.aShots.push(coords[1][1]);
+              this.aShots.push(coords[2][1]);
+            }
+            break;
+          case 4:
+            if (random <= 50) {
+              this.aShots.push(coords[0][0]);
+              this.aShots.push(coords[2][0]);
+              this.aShots.push(coords[0][2]);
+              this.aShots.push(coords[2][2]);
+            } else if (random <= 100) {
+              this.aShots.push(coords[1][0]);
+              this.aShots.push(coords[0][1]);
+              this.aShots.push(coords[2][1]);
+              this.aShots.push(coords[1][2]);
+            }
+            break;
+          default:
+          case 5:
+            if (random <= 50) {
+              this.aShots.push(coords[0][0]);
+              this.aShots.push(coords[2][0]);
+              this.aShots.push(coords[0][2]);
+              this.aShots.push(coords[2][2]);
+              this.aShots.push(coords[1][1]);
+            } else if (random <= 100) {
+              this.aShots.push(coords[1][0]);
+              this.aShots.push(coords[0][1]);
+              this.aShots.push(coords[2][1]);
+              this.aShots.push(coords[1][2]);
+              this.aShots.push(coords[1][1]);
+            }
+            break;
+          case 6:
+            if (random <= 50) {
+              this.aShots.push(coords[0][0]);
+              this.aShots.push(coords[1][0]);
+              this.aShots.push(coords[2][0]);
+              this.aShots.push(coords[0][2]);
+              this.aShots.push(coords[1][2]);
+              this.aShots.push(coords[2][2]);
+            } else if (random <= 100) {
+              this.aShots.push(coords[0][0]);
+              this.aShots.push(coords[0][1]);
+              this.aShots.push(coords[0][2]);
+              this.aShots.push(coords[2][2]);
+              this.aShots.push(coords[2][2]);
+              this.aShots.push(coords[2][2]);
+            }
+            break;
+          case 7:
+            if (random <= 50) {
+              this.aShots.push(coords[0][0]);
+              this.aShots.push(coords[1][0]);
+              this.aShots.push(coords[2][0]);
+              this.aShots.push(coords[0][2]);
+              this.aShots.push(coords[1][2]);
+              this.aShots.push(coords[2][2]);
+              this.aShots.push(coords[1][1]);
+            } else if (random <= 100) {
+              this.aShots.push(coords[0][0]);
+              this.aShots.push(coords[0][1]);
+              this.aShots.push(coords[0][2]);
+              this.aShots.push(coords[2][0]);
+              this.aShots.push(coords[2][1]);
+              this.aShots.push(coords[2][2]);
+              this.aShots.push(coords[1][1]);
+            }
+            break;
+          case 8:
+            this.aShots.push(coords[0][0]);
+            this.aShots.push(coords[0][1]);
+            this.aShots.push(coords[0][2]);
+            this.aShots.push(coords[1][0]);
+            this.aShots.push(coords[1][2]);
+            this.aShots.push(coords[2][0]);
+            this.aShots.push(coords[2][1]);
+            this.aShots.push(coords[2][2]);
+            break;
+          case 9:
+            this.aShots.push(coords[0][0]);
+            this.aShots.push(coords[0][1]);
+            this.aShots.push(coords[0][2]);
+            this.aShots.push(coords[1][0]);
+            this.aShots.push(coords[1][1]);
+            this.aShots.push(coords[1][2]);
+            this.aShots.push(coords[2][0]);
+            this.aShots.push(coords[2][1]);
+            this.aShots.push(coords[2][2]);
+            break;
+        }
+      }
     },
     /**
      * Remove an already placed mortar, specified by its index in placedMortars
@@ -1259,8 +1244,9 @@ export default {
       if (tTarget === this.target) {
         if (this.placedTargets.length > 0) {
           this.target = this.placedTargets[i === 0 ? 0 : i - 1];
-          if (this.target.pUrl == this.secondaryTarget.pUrl)
+          if (this.target.pUrl === this.secondaryTarget.pUrl) {
             this.secondaryTarget = undefined;
+          }
         } else {
           this.target = undefined;
           this.secondaryTarget = undefined;
@@ -1334,8 +1320,7 @@ export default {
       window.open("https://github.com/Endebert/squadmc", "_blank");
     },
     clearSecondaryLines() {
-      if (this.secondaryLine !== undefined)
-      {
+      if (this.secondaryLine !== undefined) {
         this.map.removeLayer(this.secondaryLine);
         this.secondaryLine = undefined;
       }
@@ -1367,12 +1352,11 @@ export default {
     },
     onDragEndListener() {
       this.dragging = false;
-      if (this.mortar && this.target)
-      {
+      if (this.mortar && this.target) {
         this.calcMortar(this.mortar, this.target, false);
         if (this.secondaryTarget) {
-            this.calcMortarSecondary(this.mortar, this.secondaryTarget, false);
-		}
+          this.calcMortarSecondary(this.mortar, this.secondaryTarget, false);
+        }
       }
     },
 
@@ -1491,12 +1475,12 @@ export default {
         this.map.removeLayer(this.distLine);
       }
     },
-    "secondaryTarget.pos" : function secondaryTargetPosWatcher() {
-        console.log("secondaryTargetPosWatcher");
-        if (this.mortar && this.target && this.secondaryTarget) {
-            this.calcMortarSecondary(this.mortar, this.secondaryTarget, this.delayCalcUpdate);
-        } else {
-            this.clearSecondaryLines();
+    "secondaryTarget.pos": function secondaryTargetPosWatcher() {
+      console.log("secondaryTargetPosWatcher");
+      if (this.mortar && this.target && this.secondaryTarget) {
+        this.calcMortarSecondary(this.mortar, this.secondaryTarget, this.delayCalcUpdate);
+      } else {
+        this.clearSecondaryLines();
       }
     },
     /**
@@ -1516,11 +1500,10 @@ export default {
       }
     },
     secondaryShots(i) {
-        this.toStorage("secondaryShots", i);
-        if (this.advancedMode && this.target && this.secondaryTarget && this.tTypeIndex > TARGET_TYPE.POINT)
-        {
-            this.calcShots();
-        }
+      this.toStorage("secondaryShots", i);
+      if (this.advancedMode && this.target && this.secondaryTarget && this.tTypeIndex > TARGET_TYPE.POINT) {
+        this.calcShots();
+      }
     },
     /**
      * Resets map when advancedMode is disabled (fixes orphaned markers)
@@ -1536,7 +1519,7 @@ export default {
         while (this.placedTargets.length > 0) {
           this.removeTarget(0);
         }
-        //set targetType to point
+        // set targetType to point
         this.tTypeIndex = 0;
       }
       this.toStorage("advancedMode", b);
@@ -1593,14 +1576,13 @@ export default {
       this.toStorage("hideLoadingBar", b);
     },
     tTypeIndex(newIndex) {
-        this.toStorage("tTypeIndex", newIndex);
-        this.placedTargets.forEach((marker) => {
-            if (marker.sUrl != this.target.sUrl)
-            {
-                this.secondaryTarget = marker;
-            }
-        });
-        this.drawSecondaryLine();
+      this.toStorage("tTypeIndex", newIndex);
+      this.placedTargets.forEach((marker) => {
+        if (marker.sUrl !== this.target.sUrl) {
+          this.secondaryTarget = marker;
+        }
+      });
+      this.drawSecondaryLine();
     },
 
     /* PostScriptum exclusive */
@@ -1617,8 +1599,10 @@ export default {
 
       if (this.mortar && this.target) {
         this.calcMortar(this.mortar, this.target);
+        if (this.secondaryTarget) {
+          this.calcMortarSecondary(this.mortar, this.secondaryTarget);
+        }
       }
-
       this.toStorage("mTypeIndex", newIndex);
     },
   },
@@ -1635,7 +1619,7 @@ export default {
      * @return {String} formatted string
      */
     DOMelevation() {
-        return this.formatDOMElevation(this.c.elevation);
+      return this.formatDOMElevation(this.c.elevation);
     },
     /**
      * Returns formatted dist string for DOM element
@@ -1656,13 +1640,13 @@ export default {
     },
 
     DOMminbearing() {
-        const minBearing = this.c.bearing <= this.c2.bearing ? this.c.bearing : this.c2.bearing;
-        return this.formatDOMBearing(minBearing);
+      const minBearing = this.c.bearing <= this.c2.bearing ? this.c.bearing : this.c2.bearing;
+      return this.formatDOMBearing(minBearing);
     },
 
     DOMmaxbearing() {
-        const maxBearing = this.c.bearing >= this.c2.bearing ? this.c.bearing : this.c2.bearing;
-        return this.formatDOMBearing(maxBearing);
+      const maxBearing = this.c.bearing >= this.c2.bearing ? this.c.bearing : this.c2.bearing;
+      return this.formatDOMBearing(maxBearing);
     },
     DOMminelevation() {
       const minElevation = this.c.elevation <= this.c2.elevation ? this.c.elevation : this.c2.elevation;
@@ -1683,8 +1667,8 @@ export default {
       return this.mortarTypes[this.mTypeIndex];
     },
     currentTType() {
-        return this.targetTypes[this.tTypeIndex];
-    }
+      return this.targetTypes[this.tTypeIndex];
+    },
   },
 };
 </script>

--- a/src/Map.vue
+++ b/src/Map.vue
@@ -1030,7 +1030,7 @@ export default {
     },
     calcBearingBetween2Pos(posA, posB) {
       // oh no, vector maths!
-      let bearing = Math.atan2(posA.lng - posB.lng, posA.lat - posB.lat) * 180 / Math.PI;
+      let bearing = Math.atan2(posB.lng - posA.lng, posB.lat - posA.lat) * 180 / Math.PI;
       bearing = (Math.round((180 - bearing) * 10) / 10) % 360;
 
       return bearing;

--- a/src/Map.vue
+++ b/src/Map.vue
@@ -1133,9 +1133,8 @@ export default {
       this.removeSubTargets();
       if (this.tTypeIndex === TARGET_TYPE.LINE) {
         const interval = this.secondaryShots - 2;
-        const boundaries = this.getCoordsBoundaries();
-        const latVariation = (boundaries.maxLat - boundaries.minLat) / (interval + 1);
-        const lngVariation = (boundaries.maxLng - boundaries.minLng) / (interval + 1);
+        const latVariation = (this.secondaryTarget.pos.lat - this.target.pos.lat) / (interval + 1);
+        const lngVariation = (this.secondaryTarget.pos.lng - this.target.pos.lng) / (interval + 1);
 
         this.addSubtarget({
           lat: this.target.pos.lat,
@@ -1147,7 +1146,7 @@ export default {
         const point = {};
         let coord;
         for (let i = 1; i <= interval; i++) { // Interval shots are computed
-          point.pos = new LatLng(boundaries.minLat + (latVariation * i), boundaries.minLng + (lngVariation * i));
+          point.pos = new LatLng(this.target.pos.lat + (latVariation * i), this.target.pos.lng + (lngVariation * i));
           coord = this.coordMortar(this.mortar, point);
           this.addSubtarget({
             lat: point.pos.lat,

--- a/src/Map.vue
+++ b/src/Map.vue
@@ -82,6 +82,24 @@
         </v-list-tile-content>
       </v-list-tile>
     </v-list>
+	<v-divider></v-divider>
+    <v-list class="pa-0" two-line v-if="advancedMode">
+      <v-list-tile>
+        <v-list-tile-content>
+          <v-list-tile-title>Set target type</v-list-tile-title>
+          <v-list-tile-sub-title>
+            <v-btn-toggle v-model="tTypeIndex" mandatory style="display: flex">
+              <v-btn flat v-for="(tType, i) in targetTypes" :key="i"
+                     style="flex: 1 0 0; border: none">{{tType}}</v-btn>
+            </v-btn-toggle></v-list-tile-sub-title>
+        </v-list-tile-content>
+      </v-list-tile>
+	  <v-list-tile>
+          <div class="pr-3">Rounds</div>
+          <v-slider v-model="secondaryShots" hide-details thumb-label class="pa-0 pr-3"
+                    step="1" min="3" max="9" ticks></v-slider>
+        </v-list-tile>
+    </v-list>
     <v-divider v-if="postScriptum"></v-divider>
     <v-list class="pa-0">
       <v-list-group>
@@ -330,17 +348,31 @@
           <v-btn icon
                  v-for="(aTarget, index) in placedTargets"
                  :key="index"
+				 v-if="secondaryTarget !== undefined && aTarget.sUrl != secondaryTarget.sUrl"
                  @click="target = placedTargets[index]">
             <img :src="aTarget.sUrl" style="width: 48px;">
           </v-btn>
         </v-speed-dial>
-        <div class="font-mono flex column" >
+		<v-icon v-if="tTypeIndex > TARGET_TYPE.POINT && secondaryTarget">arrow_forward</v-icon>
+		<v-speed-dial v-if="tTypeIndex > TARGET_TYPE.POINT && secondaryTarget">
+          <v-btn fab small slot="activator" class="secondary" style="width: 32px; height: 32px;">
+            <img :src="secondaryTarget.sUrl" style="width: 48px;">
+          </v-btn>
+          <v-btn icon
+                 v-for="(aTarget, index) in placedTargets"
+                 :key="index"
+				 v-if="aTarget.sUrl != target.sUrl"
+                 @click="secondaryTarget = placedTargets[index]">
+            <img :src="aTarget.sUrl" style="width: 48px;">
+          </v-btn>
+        </v-speed-dial>
+        <div class="font-mono flex column" v-if="tTypeIndex <= 0 || (tTypeIndex > TARGET_TYPE.POINT && secondaryTarget === undefined)">
           <div class="flex" style="width: 100%;">
-            <div class="px-1" style="flex: 1 0 auto; text-align: center; font-size: large"
-            >{{DOMbearing}}
+            <div class="px-1" style="flex: 1 0 auto; text-align: center; font-size: large">
+			{{DOMbearing}}
             </div>
-            <div class="px-1" style="flex: 1 0 auto; text-align: center; font-size: large"
-            >{{DOMelevation}}
+            <div class="px-1" style="flex: 1 0 auto; text-align: center; font-size: large">
+			{{DOMelevation}}
             </div>
           </div>
           <div class="flex" style="width: 100%;">
@@ -350,6 +382,43 @@
             >{{DOMhDelta}}</div>
           </div>
         </div>
+		<div class="font-mono flex column" v-if="tTypeIndex > TARGET_TYPE.POINT && secondaryTarget">
+          <div class="flex" style="width: 100%;">
+            <div class="px-1" style="flex: 1 0 auto; text-align: center; font-size: large">
+			{{DOMminbearing}}
+            </div>
+			<v-icon>arrow_forward</v-icon>
+            <div class="px-1" style="flex: 1 0 auto; text-align: center; font-size: large">
+			{{DOMmaxbearing}}
+            </div>
+          </div>
+		  <div class="flex" style="width: 100%;">
+            <div class="px-1" style="flex: 1 0 auto; text-align: center; font-size: large">
+			{{DOMminelevation}}
+            </div>
+			<v-icon>arrow_forward</v-icon>
+            <div class="px-1" style="flex: 1 0 auto; text-align: center; font-size: large">
+			{{DOMmaxelevation}}
+            </div>
+          </div>
+        </div>
+		<div class="font-mono flex column" v-if="tTypeIndex > TARGET_TYPE.POINT && secondaryTarget" v-for="(aShot, index) in aShots">
+		  <div class="flex" style="width: 100%;">
+            <div class="px-1" style="flex: 1 0 auto; text-align: center; font-size: small">
+				Round {{index + 1}}
+          </div>
+          </div>
+		  <div class="flex" style="width: 100%;">
+            <div class="px-1" style="flex: 1 0 auto; text-align: center; font-size: small">
+				{{ aShot.bearing }}
+            </div>
+          </div>
+		  <div class="flex" style="width: 100%;">
+            <div class="px-1" style="flex: 1 0 auto; text-align: center; font-size: small">
+				{{ aShot.elevation }}
+            </div>
+          </div>
+		</div>
       </div>
     </div>
   </v-content>
@@ -423,7 +492,7 @@ import Vue from "vue";
 import Vuetify from "vuetify";
 import "vuetify/dist/vuetify.min.css";
 
-import { CRS, LatLng, Map, Point, Polyline, Transformation } from "leaflet";
+import { CRS, LatLng, Map, Point, Polyline, Transformation, Rectangle } from "leaflet";
 
 import SquadGrid from "./assets/Leaflet_extensions/SquadGrid";
 import LocationLayer from "./assets/Leaflet_extensions/LocationLayer";
@@ -438,7 +507,7 @@ import {
 } from "./assets/Utils";
 import {
   ICON_SIZE,
-  PIN_TYPE, PS_3INCH_MAX_DISTANCE, PS_3INCH_VELOCITY,
+  PIN_TYPE, TARGET_TYPE, PS_3INCH_MAX_DISTANCE, PS_3INCH_VELOCITY,
   PS_4INCH_MAX_DISTANCE,
   PS_4INCH_VELOCITY,
   PS_8CM_MAX_DISTANCE,
@@ -486,7 +555,11 @@ export default {
       calcTimeout: undefined, // value of timeout for delayed calculations set, see calcMortar()
       mortar: undefined, // active mortar (for line drawing)
       target: undefined, // active target (for line drawing)
+	  secondaryTarget: undefined, // secondary target (for line and area target type)
+	  secondaryShots: Number.parseInt(this.fromStorage("secondaryShots", "5"), 10),
       distLine: undefined, // the line
+	  secondaryLine: undefined,// The secondary line
+	  aShots: [], // values of intermediary shots (for line and area target)
       // available colors
       colors: {
         pin: {
@@ -517,7 +590,14 @@ export default {
         dist: undefined,
         hDelta: undefined,
       },
-
+	  // secondaries values for mortar settings, distance, etc.
+	  c2: {
+        bearing: undefined,
+        elevation: undefined,
+        dist: undefined,
+        hDelta: undefined,
+      },
+	  TARGET_TYPE, // reference to target types
       PIN_TYPE, // reference to pin types
       pad, // reference to padding function used for formatting distance, heightDiff, etc.
 
@@ -538,6 +618,13 @@ export default {
         mError: false,
         tError: false,
       },
+	  
+	  targetTypes: [
+		"POINT",
+		"LINE",
+		"AREA"
+	  ],
+	  tTypeIndex: Number.parseInt(this.fromStorage("tTypeIndex", "0"), 10),
 
       /* PostScriptum exclusive */
       mortarTypes: [
@@ -545,7 +632,7 @@ export default {
         ["BRIT 4″", PS_4INCH_VELOCITY, PS_4INCH_MAX_DISTANCE],
         ["BRIT 3″", PS_3INCH_VELOCITY, PS_3INCH_MAX_DISTANCE],
       ],
-      mTypeIndex: Number.parseInt(this.fromStorage("mTypeIndex", "0"), 10),
+	  mTypeIndex: Number.parseInt(this.fromStorage("mTypeIndex", "0"), 10)
     };
   },
   mounted() {
@@ -616,6 +703,7 @@ export default {
       // clear map related objects
       this.mortar = undefined;
       this.target = undefined;
+	  this.targetSecondary = undefined;
       this.placedTargets = [];
       this.placedMortars = [];
       this.placedFobs = [];
@@ -777,13 +865,20 @@ export default {
           for (let i = 0; i < this.placedTargets.length; i += 1) {
             if (this.colors.pin.target[urlIndex] === this.placedTargets[i].pUrl) {
               this.placedTargets[i].pos = pos;
-              this.target = this.placedTargets[i];
+			  if (this.placedTargets[i].pUrl == this.secondaryTarget.pUrl)
+				this.secondaryTarget = this.placedTargets[i];
+			  else
+				this.target = this.placedTargets[i];
               return;
             }
           }
           pin = new PinHolder(type, this.colors.pin.target[urlIndex], this.pinSize);
           this.placedTargets.push(pin);
-          this.target = pin;
+		  if (this.tTypeIndex > TARGET_TYPE.POINT && this.target !== undefined) {
+			this.secondaryTarget = pin;
+		  }
+		  else
+			this.target = pin;
           break;
         case PIN_TYPE.FOB:
           for (let i = 0; i < this.placedFobs.length; i += 1) {
@@ -808,18 +903,42 @@ export default {
         pin.addTo(this.map);
       }
     },
-    /**
-     * Calculates mortar settings.
-     *
-     * @param {PinHolder} mortar - mortar pin
-     * @param {PinHolder} target - target pin
-     * @param {Boolean} delayUpdate - whether or not to delay updating values for DOM
-     */
-    calcMortar(mortar, target, delayUpdate = true) {
-      console.log("calcMortar", [mortar, target]);
-
-      const s = mortar.pos;
+	drawSecondaryLine() {
+		console.log("drawSecondaryLines()");
+		this.clearSecondaryLines();
+		if (this.advancedMode && this.target && this.secondaryTarget)
+		{
+			if (this.tTypeIndex === TARGET_TYPE.LINE)//Line target type
+			{
+				const line = new Polyline([this.target.pos, this.secondaryTarget.pos], {
+				  color: "#3333ff",
+				  interactive: false,
+				  clickable: false, // legacy support
+				});
+				if (!this.map.hasLayer(line)) {
+					this.secondaryLine = line;
+					this.map.addLayer(line);
+				}
+			}
+			if (this.tTypeIndex == TARGET_TYPE.AREA)//Area target type
+			{
+				const rectangle = new Rectangle([
+													[this.target.pos.lat, this.target.pos.lng],
+													[this.secondaryTarget.pos.lat, this.secondaryTarget.pos.lng]
+												], 
+												{color:"#3333ff", weight: 1});
+				if (!this.map.hasLayer(rectangle)) {
+					this.secondaryLine = rectangle;
+					this.map.addLayer(rectangle);
+				}
+			}
+		}
+	},
+	coordMortar(mortar, target) {
+	  const s = mortar.pos;
       const e = target.pos;
+	  
+	  const coords = {};
 
       // oh no, vector maths!
       let bearing = Math.atan2(e.lng - s.lng, e.lat - s.lat) * 180 / Math.PI;
@@ -839,6 +958,28 @@ export default {
       const hDelta = targetHeight - mortarHeight;
       const mVelocity = this.postScriptum ? this.currentMType[1] : SQUAD_VELOCITY;
       const elevation = calcMortarAngle(dist, hDelta, mVelocity);
+	  
+	  const newC = {
+        bearing,
+        elevation,
+        dist,
+        hDelta,
+      };
+	  
+	  return newC;
+	},
+    /**
+     * Calculates mortar settings.
+     *
+     * @param {PinHolder} mortar - mortar pin
+     * @param {PinHolder} target - target pin
+     * @param {Boolean} delayUpdate - whether or not to delay updating values for DOM
+     */
+    calcMortar(mortar, target, delayUpdate = true) {
+      console.log("calcMortar", [mortar, target]);
+
+      const s = mortar.pos;
+      const e = target.pos;
 
       // create or move the line
       if (!this.distLine) {
@@ -850,10 +991,13 @@ export default {
       } else {
         this.distLine.setLatLngs([s, e]);
       }
+	  
+	  // new this.c object before setting it
+      const newC = this.coordMortar(mortar, target);
 
       // isNaN is used as elevation might be NaN
       this.distLine.setStyle({
-        color: Number.isNaN(elevation) || elevation > 1580 || elevation < 800 ? "#f44336" : "#4caf50",
+        color: Number.isNaN(newC.elevation) || newC.elevation > 1580 || newC.elevation < 800 ? "#f44336" : "#4caf50",
       });
 
       // add to map if it isn't shown yet
@@ -861,13 +1005,7 @@ export default {
         this.map.addLayer(this.distLine);
       }
 
-      // new this.c object before setting it
-      const newC = {
-        bearing,
-        elevation,
-        dist,
-        hDelta,
-      };
+      
 
       if (this.calcTimeout) { clearTimeout(this.calcTimeout); }
 
@@ -880,6 +1018,218 @@ export default {
         this.c = newC;
       }
     },
+	calcMortarSecondary(mortar, target, delayUpdate = true) {
+      console.log("calcMortarSecondary", [mortar, target]);
+
+      const newC = this.coordMortar(mortar, target);
+	
+	  this.drawSecondaryLine();
+      if (this.calcTimeout) { clearTimeout(this.calcTimeout); }
+
+      // if we want to delay the calc update, we set a timer that will set this.c
+      if (delayUpdate) {
+        this.calcTimeout = setTimeout(() => {
+          this.c2 = newC;
+		  this.calcShots();
+        }, 250);
+      } else {
+        this.c2 = newC;
+		this.calcShots();
+      }
+	  
+    },
+	getCoordsBoundaries() {
+		return {
+			minLat: this.target.pos.lat <= this.secondaryTarget.pos.lat ? this.target.pos.lat : this.secondaryTarget.pos.lat,
+			maxLat: this.target.pos.lat > this.secondaryTarget.pos.lat ? this.target.pos.lat : this.secondaryTarget.pos.lat,
+			minLng: this.target.pos.lng <= this.secondaryTarget.pos.lng ? this.target.pos.lng : this.secondaryTarget.pos.lng,
+			maxLng: this.target.pos.lng > this.secondaryTarget.pos.lng ? this.target.pos.lng : this.secondaryTarget.pos.lng,
+		};
+	},
+	calcShots() {
+		if (this.tTypeIndex == TARGET_TYPE.LINE)
+		{
+			const interval = this.secondaryShots - 2;
+			const boundaries = this.getCoordsBoundaries();
+			const latVariation = (boundaries.maxLat - boundaries.minLat) / (interval + 1);
+			const lngVariation = (boundaries.maxLng - boundaries.minLng) / (interval + 1);
+			
+			this.aShots = [];
+			this.aShots.push({
+				bearing: this.formatDOMBearing(this.c.bearing),
+				elevation: this.formatDOMElevation(this.c.elevation)
+			});//First shot is fixed
+			
+			const point = {};
+			let coord;
+			for (let i = 1; i <= interval; i++)//Interval shots are computed
+			{
+				point.pos = new LatLng(boundaries.minLat + (latVariation * i), boundaries.minLng + (lngVariation * i), );
+				coord = this.coordMortar(this.mortar, point);
+				this.aShots.push({
+					bearing: this.formatDOMBearing(coord.bearing),
+					elevation: this.formatDOMElevation(coord.elevation)
+				});
+			}
+			
+			this.aShots.push({
+				bearing: this.formatDOMBearing(this.c2.bearing),
+				elevation: this.formatDOMElevation(this.c2.elevation)
+			});//Last shot is fixed
+			console.log("calcShots", this.shots);
+		}
+		if (this.tTypeIndex == TARGET_TYPE.AREA)
+		{
+			this.aShots = [];
+			const interval = 3;
+			const boundaries = this.getCoordsBoundaries();
+			const latVariation = (boundaries.maxLat - boundaries.minLat) / (interval + 1);
+			const lngVariation = (boundaries.maxLng - boundaries.minLng) / (interval + 1);
+			
+			const latitudes = [];
+			const longitudes = [];
+			for (let i = 1; i <= interval; i++)
+			{
+				latitudes.push(boundaries.minLat + (latVariation * i));
+				longitudes.push(boundaries.minLng + (lngVariation * i));
+			}
+			const coords = [];
+			const point = {};
+			let coord;
+			for (let i = 0; i < interval; i++)
+			{
+				for (let j = 0; j < interval; j++)
+				{
+					point.pos = new LatLng(latitudes[i], longitudes[j]);
+					coord = this.coordMortar(this.mortar, point);
+					if (coords[i] === undefined)
+						coords[i] = [];
+					coords[i][j] = {
+						bearing: this.formatDOMBearing(coord.bearing),
+						elevation: this.formatDOMElevation(coord.elevation)
+					};
+				}
+			}
+			const random = Math.floor(Math.random() * Math.floor(100));// get random value between 0-100
+			switch (this.secondaryShots){//will choose a random pattern on the 9 points available depends of the numbers of points wanted
+				case 3:
+					if (random <= 25)
+					{
+						this.aShots.push(coords[0][0]);
+						this.aShots.push(coords[1][1]);
+						this.aShots.push(coords[2][2]);
+					}
+					else if (random <= 50)
+					{
+						this.aShots.push(coords[0][2]);
+						this.aShots.push(coords[1][1]);
+						this.aShots.push(coords[2][0]);
+					}
+					else if (random <= 75)
+					{
+						this.aShots.push(coords[1][0]);
+						this.aShots.push(coords[1][1]);
+						this.aShots.push(coords[1][2]);
+					}
+					else if (random <= 100)
+					{
+						this.aShots.push(coords[0][1]);
+						this.aShots.push(coords[1][1]);
+						this.aShots.push(coords[2][1]);
+					}
+					break;
+				case 4:
+					if (random <= 50) {
+						this.aShots.push(coords[0][0]);
+						this.aShots.push(coords[2][0]);
+						this.aShots.push(coords[0][2]);
+						this.aShots.push(coords[2][2]);
+					}
+					else if (random <= 100){
+						this.aShots.push(coords[1][0]);
+						this.aShots.push(coords[0][1]);
+						this.aShots.push(coords[2][1]);
+						this.aShots.push(coords[1][2]);
+					}
+					break;
+				case 5:
+					if (random <= 50) {
+						this.aShots.push(coords[0][0]);
+						this.aShots.push(coords[2][0]);
+						this.aShots.push(coords[0][2]);
+						this.aShots.push(coords[2][2]);
+						this.aShots.push(coords[1][1]);
+					}
+					else if (random <= 100){
+						this.aShots.push(coords[1][0]);
+						this.aShots.push(coords[0][1]);
+						this.aShots.push(coords[2][1]);
+						this.aShots.push(coords[1][2]);
+						this.aShots.push(coords[1][1]);
+					}
+					break;
+				case 6:
+					if (random <= 50) {
+						this.aShots.push(coords[0][0]);
+						this.aShots.push(coords[1][0]);
+						this.aShots.push(coords[2][0]);
+						this.aShots.push(coords[0][2]);
+						this.aShots.push(coords[1][2]);
+						this.aShots.push(coords[2][2]);
+					}
+					else if (random <= 100){
+						this.aShots.push(coords[0][0]);
+						this.aShots.push(coords[0][1]);
+						this.aShots.push(coords[0][2]);
+						this.aShots.push(coords[2][2]);
+						this.aShots.push(coords[2][2]);
+						this.aShots.push(coords[2][2]);
+					}
+					break;
+				case 7:
+					if (random <= 50) {
+						this.aShots.push(coords[0][0]);
+						this.aShots.push(coords[1][0]);
+						this.aShots.push(coords[2][0]);
+						this.aShots.push(coords[0][2]);
+						this.aShots.push(coords[1][2]);
+						this.aShots.push(coords[2][2]);
+						this.aShots.push(coords[1][1]);
+					}
+					else if (random <= 100){
+						this.aShots.push(coords[0][0]);
+						this.aShots.push(coords[0][1]);
+						this.aShots.push(coords[0][2]);
+						this.aShots.push(coords[2][0]);
+						this.aShots.push(coords[2][1]);
+						this.aShots.push(coords[2][2]);
+						this.aShots.push(coords[1][1]);
+					}
+					break;
+				case 8:
+					this.aShots.push(coords[0][0]);
+					this.aShots.push(coords[0][1]);
+					this.aShots.push(coords[0][2]);
+					this.aShots.push(coords[1][0]);
+					this.aShots.push(coords[1][2]);
+					this.aShots.push(coords[2][0]);
+					this.aShots.push(coords[2][1]);
+					this.aShots.push(coords[2][2]);
+					break;
+				case 9:
+					this.aShots.push(coords[0][0]);
+					this.aShots.push(coords[0][1]);
+					this.aShots.push(coords[0][2]);
+					this.aShots.push(coords[1][0]);
+					this.aShots.push(coords[1][1]);
+					this.aShots.push(coords[1][2]);
+					this.aShots.push(coords[2][0]);
+					this.aShots.push(coords[2][1]);
+					this.aShots.push(coords[2][2]);
+					break;
+			}
+		}
+	},
     /**
      * Remove an already placed mortar, specified by its index in placedMortars
      * @param {Number} i - index of mortar in placedMortars
@@ -909,12 +1259,24 @@ export default {
       if (tTarget === this.target) {
         if (this.placedTargets.length > 0) {
           this.target = this.placedTargets[i === 0 ? 0 : i - 1];
+		  if (this.target.pUrl == this.secondaryTarget.pUrl)
+			this.secondaryTarget = undefined;
         } else {
           this.target = undefined;
+		  this.secondaryTarget = undefined;
         }
       }
       tTarget.removeFrom(this.map);
     },
+	formatDOMElevation(elevation) {
+		if (Number.isNaN(elevation) || elevation > 1580 || elevation < 800) {
+			return "∠XXXX.Xmil";
+		}
+      return `∠${pad((Math.round(elevation * 10) / 10).toFixed(1), 6)}mil`;
+	},
+	formatDOMBearing(bearing) {
+		return `✵${pad((Math.round(bearing * 10) / 10).toFixed(1), 5)}°`;
+	},
     /**
      * Remove an already placed fob, specified by its index in placedFobs
      * @param {Number} i - index of fob in placedFobs
@@ -971,6 +1333,13 @@ export default {
     openGitHub() {
       window.open("https://github.com/Endebert/squadmc", "_blank");
     },
+	clearSecondaryLines() {
+		if (this.secondaryLine !== undefined)
+		{
+			this.map.removeLayer(this.secondaryLine);
+			this.secondaryLine = undefined;
+		}
+	},
 
     /**
      * This function works in tandem with showHeightmap watcher.
@@ -998,7 +1367,12 @@ export default {
     },
     onDragEndListener() {
       this.dragging = false;
-      if (this.mortar && this.target) { this.calcMortar(this.mortar, this.target, false); }
+      if (this.mortar && this.target) 
+	  { 
+		this.calcMortar(this.mortar, this.target, false);
+		if (this.secondaryTarget)
+			this.calcMortarSecondary(this.mortar, this.secondaryTarget, false);
+	  }
     },
 
     /**
@@ -1099,6 +1473,7 @@ export default {
       console.log("mortarPosWatcher");
       if (this.mortar && this.target) {
         this.calcMortar(this.mortar, this.target, this.delayCalcUpdate);
+		this.calcMortarSecondary(this.mortar, this.secondaryTarget, this.delayCalcUpdate);
       } else if (this.map.hasLayer(this.distLine)) {
         this.map.removeLayer(this.distLine);
       }
@@ -1110,10 +1485,19 @@ export default {
       console.log("targetPosWatcher");
       if (this.mortar && this.target) {
         this.calcMortar(this.mortar, this.target, this.delayCalcUpdate);
+		this.drawSecondaryLine();
       } else if (this.map.hasLayer(this.distLine)) {
         this.map.removeLayer(this.distLine);
       }
     },
+	"secondaryTarget.pos" : function secondaryTargetPosWatcher() {
+		console.log("secondaryTargetPosWatcher");
+		if (this.mortar && this.target && this.secondaryTarget) {
+			this.calcMortarSecondary(this.mortar, this.secondaryTarget, this.delayCalcUpdate);
+		} else {
+			this.clearSecondaryLines();
+      }
+	},
     /**
      * let new active mortar know that it is active now (in order to show min and max range circles)
      * @param {PinHolder} newM - new active mortar
@@ -1130,6 +1514,13 @@ export default {
         newM.setActive(true, this.map);
       }
     },
+	secondaryShots(i) {
+		this.toStorage("secondaryShots", i);
+		if (this.advancedMode && this.target && this.secondaryTarget && this.tTypeIndex > TARGET_TYPE.POINT)
+		{
+			this.calcShots();
+		}
+	},
     /**
      * Resets map when advancedMode is disabled (fixes orphaned markers)
      * @param {Boolean} b - advancedMode state boolean
@@ -1144,6 +1535,8 @@ export default {
         while (this.placedTargets.length > 0) {
           this.removeTarget(0);
         }
+		//set targetType to point
+		this.tTypeIndex = 0;
       }
       this.toStorage("advancedMode", b);
     },
@@ -1198,6 +1591,16 @@ export default {
     hideLoadingBar(b) {
       this.toStorage("hideLoadingBar", b);
     },
+	tTypeIndex(newIndex) {
+		this.toStorage("tTypeIndex", newIndex);
+		this.placedTargets.forEach((marker) => {
+			if (marker.sUrl != this.target.sUrl)
+			{
+				this.secondaryTarget = marker;
+			}
+		});
+		this.drawSecondaryLine();
+	},
 
     /* PostScriptum exclusive */
 
@@ -1224,17 +1627,14 @@ export default {
      * @return {String} formatted string
      */
     DOMbearing() {
-      return `✵${pad((Math.round(this.c.bearing * 10) / 10).toFixed(1), 5)}°`;
+      return this.formatDOMBearing(this.c.bearing);
     },
     /**
      * Returns formatted elevation string for DOM element
      * @return {String} formatted string
      */
     DOMelevation() {
-      if (Number.isNaN(this.c.elevation) || this.c.elevation > 1580 || this.c.elevation < 800) {
-        return "∠XXXX.Xmil";
-      }
-      return `∠${pad((Math.round(this.c.elevation * 10) / 10).toFixed(1), 6)}mil`;
+		return this.formatDOMElevation(this.c.elevation);
     },
     /**
      * Returns formatted dist string for DOM element
@@ -1253,6 +1653,24 @@ export default {
       }
       return `↕-${pad(Math.round(-this.c.hDelta), 3)}m`;
     },
+	
+	DOMminbearing() {
+		const minBearing = this.c.bearing <= this.c2.bearing ? this.c.bearing : this.c2.bearing;
+		return this.formatDOMBearing(minBearing);
+	},
+	
+	DOMmaxbearing() {
+		const maxBearing = this.c.bearing >= this.c2.bearing ? this.c.bearing : this.c2.bearing;
+		return this.formatDOMBearing(maxBearing);
+	},
+	DOMminelevation() {
+	  const minElevation = this.c.elevation <= this.c2.elevation ? this.c.elevation : this.c2.elevation;
+      return this.formatDOMElevation(minElevation);
+    },
+	DOMmaxelevation() {
+	  const maxElevation = this.c.elevation >= this.c2.elevation ? this.c.elevation : this.c2.elevation;
+      return this.formatDOMElevation(maxElevation);
+    },
 
     /* PostScriptum exclusive */
 
@@ -1263,6 +1681,9 @@ export default {
     currentMType() {
       return this.mortarTypes[this.mTypeIndex];
     },
+	currentTType() {
+		return this.targetTypes[this.tTypeIndex];
+	}
   },
 };
 </script>

--- a/src/Map.vue
+++ b/src/Map.vue
@@ -1098,6 +1098,8 @@ export default {
     addSubtarget(coords) {
       const subTargetIndex = this.aSubTargets.length;
       const pos = new LatLng(coords.lat, coords.lng);
+      const color = Number.isNaN(coords.elevation)
+       || coords.elevation > 1580 || coords.elevation < 800 ? "#f44336" : "#4caf50";
       const subTarget = {
         pos,
         coords: {
@@ -1107,7 +1109,7 @@ export default {
           DOMElevation: this.formatDOMElevation(coords.elevation),
         },
         mapLayer: new Circle(pos, {
-          color: "#ff3333",
+          color,
           fillOpacity: 1,
           bubblingMouseEvents: false,
           subTargetIndex, // additionnal options in order to handle easily click event

--- a/src/Map.vue
+++ b/src/Map.vue
@@ -1685,6 +1685,7 @@ export default {
         }
       });
       this.drawSecondaryLine();
+      this.calcSubTargets();
     },
 
     currentSubTarget(index) {

--- a/src/Map.vue
+++ b/src/Map.vue
@@ -82,7 +82,7 @@
         </v-list-tile-content>
       </v-list-tile>
     </v-list>
-	<v-divider></v-divider>
+    <v-divider></v-divider>
     <v-list class="pa-0" two-line v-if="advancedMode">
       <v-list-tile>
         <v-list-tile-content>
@@ -94,7 +94,7 @@
             </v-btn-toggle></v-list-tile-sub-title>
         </v-list-tile-content>
       </v-list-tile>
-	   <v-list-tile v-if="tTypeIndex > TARGET_TYPE.POINT">
+       <v-list-tile v-if="tTypeIndex > TARGET_TYPE.POINT">
           <div class="pr-3">Rounds</div>
           <v-slider v-model="secondaryShots" hide-details thumb-label class="pa-0 pr-3"
                     step="1" min="3" max="9" thumb-label="always" :thumb-size="24" ticks></v-slider>
@@ -348,20 +348,20 @@
           <v-btn icon
                  v-for="(aTarget, index) in placedTargets"
                  :key="index"
-				 v-if="secondaryTarget !== undefined && aTarget.sUrl != secondaryTarget.sUrl"
+                 v-if="secondaryTarget !== undefined && aTarget.sUrl != secondaryTarget.sUrl"
                  @click="target = placedTargets[index]">
             <img :src="aTarget.sUrl" style="width: 48px;">
           </v-btn>
         </v-speed-dial>
-		<v-icon v-if="tTypeIndex > TARGET_TYPE.POINT && secondaryTarget">arrow_forward</v-icon>
-		<v-speed-dial v-if="tTypeIndex > TARGET_TYPE.POINT && secondaryTarget">
+        <v-icon v-if="tTypeIndex > TARGET_TYPE.POINT && secondaryTarget">arrow_forward</v-icon>
+        <v-speed-dial v-if="tTypeIndex > TARGET_TYPE.POINT && secondaryTarget">
           <v-btn fab small slot="activator" class="secondary" style="width: 32px; height: 32px;">
             <img :src="secondaryTarget.sUrl" style="width: 48px;">
           </v-btn>
           <v-btn icon
                  v-for="(aTarget, index) in placedTargets"
                  :key="index"
-				 v-if="aTarget.sUrl != target.sUrl"
+                 v-if="aTarget.sUrl != target.sUrl"
                  @click="secondaryTarget = placedTargets[index]">
             <img :src="aTarget.sUrl" style="width: 48px;">
           </v-btn>
@@ -369,10 +369,10 @@
         <div class="font-mono flex column" v-if="tTypeIndex <= 0 || (tTypeIndex > TARGET_TYPE.POINT && secondaryTarget === undefined)">
           <div class="flex" style="width: 100%;">
             <div class="px-1" style="flex: 1 0 auto; text-align: center; font-size: large">
-			{{DOMbearing}}
+            {{DOMbearing}}
             </div>
             <div class="px-1" style="flex: 1 0 auto; text-align: center; font-size: large">
-			{{DOMelevation}}
+            {{DOMelevation}}
             </div>
           </div>
           <div class="flex" style="width: 100%;">
@@ -382,43 +382,43 @@
             >{{DOMhDelta}}</div>
           </div>
         </div>
-		<div class="font-mono flex column" v-if="tTypeIndex > TARGET_TYPE.POINT && secondaryTarget">
+        <div class="font-mono flex column" v-if="tTypeIndex > TARGET_TYPE.POINT && secondaryTarget">
           <div class="flex" style="width: 100%;">
             <div class="px-1" style="flex: 1 0 auto; text-align: center; font-size: large">
-			{{DOMminbearing}}
+            {{DOMminbearing}}
             </div>
-			<v-icon>arrow_forward</v-icon>
+            <v-icon>arrow_forward</v-icon>
             <div class="px-1" style="flex: 1 0 auto; text-align: center; font-size: large">
-			{{DOMmaxbearing}}
+            {{DOMmaxbearing}}
             </div>
           </div>
-		  <div class="flex" style="width: 100%;">
+          <div class="flex" style="width: 100%;">
             <div class="px-1" style="flex: 1 0 auto; text-align: center; font-size: large">
-			{{DOMminelevation}}
+            {{DOMminelevation}}
             </div>
-			<v-icon>arrow_forward</v-icon>
+            <v-icon>arrow_forward</v-icon>
             <div class="px-1" style="flex: 1 0 auto; text-align: center; font-size: large">
-			{{DOMmaxelevation}}
+            {{DOMmaxelevation}}
             </div>
           </div>
         </div>
-		<div class="font-mono flex column" v-if="tTypeIndex > TARGET_TYPE.POINT && secondaryTarget" v-for="(aShot, index) in aShots">
-		  <div class="flex" style="width: 100%;">
+        <div class="font-mono flex column" v-if="tTypeIndex > TARGET_TYPE.POINT && secondaryTarget" v-for="(aShot, index) in aShots">
+          <div class="flex" style="width: 100%;">
             <div class="px-1" style="flex: 1 0 auto; text-align: center; font-size: small">
-				Round {{index + 1}}
+                Round {{index + 1}}
           </div>
           </div>
-		  <div class="flex" style="width: 100%;">
+          <div class="flex" style="width: 100%;">
             <div class="px-1" style="flex: 1 0 auto; text-align: center; font-size: small">
-				{{ aShot.bearing }}
+                {{ aShot.bearing }}
             </div>
           </div>
-		  <div class="flex" style="width: 100%;">
+          <div class="flex" style="width: 100%;">
             <div class="px-1" style="flex: 1 0 auto; text-align: center; font-size: small">
-				{{ aShot.elevation }}
+                {{ aShot.elevation }}
             </div>
           </div>
-		</div>
+        </div>
       </div>
     </div>
   </v-content>
@@ -555,11 +555,11 @@ export default {
       calcTimeout: undefined, // value of timeout for delayed calculations set, see calcMortar()
       mortar: undefined, // active mortar (for line drawing)
       target: undefined, // active target (for line drawing)
-	  secondaryTarget: undefined, // secondary target (for line and area target type)
-	  secondaryShots: Number.parseInt(this.fromStorage("secondaryShots", "5"), 10),
+      secondaryTarget: undefined, // secondary target (for line and area target type)
+      secondaryShots: Number.parseInt(this.fromStorage("secondaryShots", "5"), 10),
       distLine: undefined, // the line
-	  secondaryLine: undefined,// The secondary line
-	  aShots: [], // values of intermediary shots (for line and area target)
+      secondaryLine: undefined,// The secondary line
+      aShots: [], // values of intermediary shots (for line and area target)
       // available colors
       colors: {
         pin: {
@@ -590,14 +590,14 @@ export default {
         dist: undefined,
         hDelta: undefined,
       },
-	  // secondaries values for mortar settings, distance, etc.
-	  c2: {
+      // secondaries values for mortar settings, distance, etc.
+      c2: {
         bearing: undefined,
         elevation: undefined,
         dist: undefined,
         hDelta: undefined,
       },
-	  TARGET_TYPE, // reference to target types
+      TARGET_TYPE, // reference to target types
       PIN_TYPE, // reference to pin types
       pad, // reference to padding function used for formatting distance, heightDiff, etc.
 
@@ -618,13 +618,13 @@ export default {
         mError: false,
         tError: false,
       },
-	  
-	  targetTypes: [
-		"POINT",
-		"LINE",
-		"AREA"
-	  ],
-	  tTypeIndex: Number.parseInt(this.fromStorage("tTypeIndex", "0"), 10),
+
+      targetTypes: [
+        "POINT",
+        "LINE",
+        "AREA"
+      ],
+      tTypeIndex: Number.parseInt(this.fromStorage("tTypeIndex", "0"), 10),
 
       /* PostScriptum exclusive */
       mortarTypes: [
@@ -632,7 +632,7 @@ export default {
         ["BRIT 4″", PS_4INCH_VELOCITY, PS_4INCH_MAX_DISTANCE],
         ["BRIT 3″", PS_3INCH_VELOCITY, PS_3INCH_MAX_DISTANCE],
       ],
-	  mTypeIndex: Number.parseInt(this.fromStorage("mTypeIndex", "0"), 10)
+      mTypeIndex: Number.parseInt(this.fromStorage("mTypeIndex", "0"), 10),
     };
   },
   mounted() {
@@ -703,7 +703,7 @@ export default {
       // clear map related objects
       this.mortar = undefined;
       this.target = undefined;
-	  this.targetSecondary = undefined;
+      this.targetSecondary = undefined;
       this.placedTargets = [];
       this.placedMortars = [];
       this.placedFobs = [];
@@ -865,20 +865,20 @@ export default {
           for (let i = 0; i < this.placedTargets.length; i += 1) {
             if (this.colors.pin.target[urlIndex] === this.placedTargets[i].pUrl) {
               this.placedTargets[i].pos = pos;
-			  if (this.placedTargets[i].pUrl == this.secondaryTarget.pUrl)
-				this.secondaryTarget = this.placedTargets[i];
-			  else
-				this.target = this.placedTargets[i];
+              if (this.placedTargets[i].pUrl == this.secondaryTarget.pUrl)
+                this.secondaryTarget = this.placedTargets[i];
+              else
+                this.target = this.placedTargets[i];
               return;
             }
           }
           pin = new PinHolder(type, this.colors.pin.target[urlIndex], this.pinSize);
           this.placedTargets.push(pin);
-		  if (this.tTypeIndex > TARGET_TYPE.POINT && this.target !== undefined) {
-			this.secondaryTarget = pin;
-		  }
-		  else
-			this.target = pin;
+          if (this.tTypeIndex > TARGET_TYPE.POINT && this.target !== undefined) {
+            this.secondaryTarget = pin;
+          }
+          else
+            this.target = pin;
           break;
         case PIN_TYPE.FOB:
           for (let i = 0; i < this.placedFobs.length; i += 1) {
@@ -903,42 +903,42 @@ export default {
         pin.addTo(this.map);
       }
     },
-	drawSecondaryLine() {
-		console.log("drawSecondaryLines()");
-		this.clearSecondaryLines();
-		if (this.advancedMode && this.target && this.secondaryTarget)
-		{
-			if (this.tTypeIndex === TARGET_TYPE.LINE)//Line target type
-			{
-				const line = new Polyline([this.target.pos, this.secondaryTarget.pos], {
-				  color: "#3333ff",
-				  interactive: false,
-				  clickable: false, // legacy support
-				});
-				if (!this.map.hasLayer(line)) {
-					this.secondaryLine = line;
-					this.map.addLayer(line);
-				}
-			}
-			if (this.tTypeIndex == TARGET_TYPE.AREA)//Area target type
-			{
-				const rectangle = new Rectangle([
-													[this.target.pos.lat, this.target.pos.lng],
-													[this.secondaryTarget.pos.lat, this.secondaryTarget.pos.lng]
-												], 
-												{color:"#3333ff", weight: 1});
-				if (!this.map.hasLayer(rectangle)) {
-					this.secondaryLine = rectangle;
-					this.map.addLayer(rectangle);
-				}
-			}
-		}
-	},
-	coordMortar(mortar, target) {
-	  const s = mortar.pos;
+    drawSecondaryLine() {
+        console.log("drawSecondaryLines()");
+        this.clearSecondaryLines();
+        if (this.advancedMode && this.target && this.secondaryTarget)
+        {
+            if (this.tTypeIndex === TARGET_TYPE.LINE)//Line target type
+            {
+                const line = new Polyline([this.target.pos, this.secondaryTarget.pos], {
+                  color: "#3333ff",
+                  interactive: false,
+                  clickable: false, // legacy support
+                });
+                if (!this.map.hasLayer(line)) {
+                    this.secondaryLine = line;
+                    this.map.addLayer(line);
+                }
+            }
+            if (this.tTypeIndex == TARGET_TYPE.AREA)//Area target type
+            {
+                const rectangle = new Rectangle([
+                                                    [this.target.pos.lat, this.target.pos.lng],
+                                                    [this.secondaryTarget.pos.lat, this.secondaryTarget.pos.lng]
+                                                ],
+                                                {color:"#3333ff", weight: 1});
+                if (!this.map.hasLayer(rectangle)) {
+                    this.secondaryLine = rectangle;
+                    this.map.addLayer(rectangle);
+                }
+            }
+        }
+    },
+    coordMortar(mortar, target) {
+      const s = mortar.pos;
       const e = target.pos;
-	  
-	  const coords = {};
+
+      const coords = {};
 
       // oh no, vector maths!
       let bearing = Math.atan2(e.lng - s.lng, e.lat - s.lat) * 180 / Math.PI;
@@ -958,16 +958,16 @@ export default {
       const hDelta = targetHeight - mortarHeight;
       const mVelocity = this.postScriptum ? this.currentMType[1] : SQUAD_VELOCITY;
       const elevation = calcMortarAngle(dist, hDelta, mVelocity);
-	  
-	  const newC = {
+
+      const newC = {
         bearing,
         elevation,
         dist,
         hDelta,
       };
-	  
-	  return newC;
-	},
+
+      return newC;
+    },
     /**
      * Calculates mortar settings.
      *
@@ -991,8 +991,8 @@ export default {
       } else {
         this.distLine.setLatLngs([s, e]);
       }
-	  
-	  // new this.c object before setting it
+
+      // new this.c object before setting it
       const newC = this.coordMortar(mortar, target);
 
       // isNaN is used as elevation might be NaN
@@ -1005,7 +1005,7 @@ export default {
         this.map.addLayer(this.distLine);
       }
 
-      
+
 
       if (this.calcTimeout) { clearTimeout(this.calcTimeout); }
 
@@ -1018,218 +1018,218 @@ export default {
         this.c = newC;
       }
     },
-	calcMortarSecondary(mortar, target, delayUpdate = true) {
+    calcMortarSecondary(mortar, target, delayUpdate = true) {
       console.log("calcMortarSecondary", [mortar, target]);
 
       const newC = this.coordMortar(mortar, target);
-	
-	  this.drawSecondaryLine();
+
+      this.drawSecondaryLine();
       if (this.calcTimeout) { clearTimeout(this.calcTimeout); }
 
       // if we want to delay the calc update, we set a timer that will set this.c
       if (delayUpdate) {
         this.calcTimeout = setTimeout(() => {
           this.c2 = newC;
-		  this.calcShots();
+          this.calcShots();
         }, 250);
       } else {
         this.c2 = newC;
-		this.calcShots();
+        this.calcShots();
       }
-	  
+
     },
-	getCoordsBoundaries() {
-		return {
-			minLat: this.target.pos.lat <= this.secondaryTarget.pos.lat ? this.target.pos.lat : this.secondaryTarget.pos.lat,
-			maxLat: this.target.pos.lat > this.secondaryTarget.pos.lat ? this.target.pos.lat : this.secondaryTarget.pos.lat,
-			minLng: this.target.pos.lng <= this.secondaryTarget.pos.lng ? this.target.pos.lng : this.secondaryTarget.pos.lng,
-			maxLng: this.target.pos.lng > this.secondaryTarget.pos.lng ? this.target.pos.lng : this.secondaryTarget.pos.lng,
-		};
-	},
-	calcShots() {
-		if (this.tTypeIndex == TARGET_TYPE.LINE)
-		{
-			const interval = this.secondaryShots - 2;
-			const boundaries = this.getCoordsBoundaries();
-			const latVariation = (boundaries.maxLat - boundaries.minLat) / (interval + 1);
-			const lngVariation = (boundaries.maxLng - boundaries.minLng) / (interval + 1);
-			
-			this.aShots = [];
-			this.aShots.push({
-				bearing: this.formatDOMBearing(this.c.bearing),
-				elevation: this.formatDOMElevation(this.c.elevation)
-			});//First shot is fixed
-			
-			const point = {};
-			let coord;
-			for (let i = 1; i <= interval; i++)//Interval shots are computed
-			{
-				point.pos = new LatLng(boundaries.minLat + (latVariation * i), boundaries.minLng + (lngVariation * i), );
-				coord = this.coordMortar(this.mortar, point);
-				this.aShots.push({
-					bearing: this.formatDOMBearing(coord.bearing),
-					elevation: this.formatDOMElevation(coord.elevation)
-				});
-			}
-			
-			this.aShots.push({
-				bearing: this.formatDOMBearing(this.c2.bearing),
-				elevation: this.formatDOMElevation(this.c2.elevation)
-			});//Last shot is fixed
-			console.log("calcShots", this.shots);
-		}
-		if (this.tTypeIndex == TARGET_TYPE.AREA)
-		{
-			this.aShots = [];
-			const interval = 3;
-			const boundaries = this.getCoordsBoundaries();
-			const latVariation = (boundaries.maxLat - boundaries.minLat) / (interval + 1);
-			const lngVariation = (boundaries.maxLng - boundaries.minLng) / (interval + 1);
-			
-			const latitudes = [];
-			const longitudes = [];
-			for (let i = 1; i <= interval; i++)
-			{
-				latitudes.push(boundaries.minLat + (latVariation * i));
-				longitudes.push(boundaries.minLng + (lngVariation * i));
-			}
-			const coords = [];
-			const point = {};
-			let coord;
-			for (let i = 0; i < interval; i++)
-			{
-				for (let j = 0; j < interval; j++)
-				{
-					point.pos = new LatLng(latitudes[i], longitudes[j]);
-					coord = this.coordMortar(this.mortar, point);
-					if (coords[i] === undefined)
-						coords[i] = [];
-					coords[i][j] = {
-						bearing: this.formatDOMBearing(coord.bearing),
-						elevation: this.formatDOMElevation(coord.elevation)
-					};
-				}
-			}
-			const random = Math.floor(Math.random() * Math.floor(100));// get random value between 0-100
-			switch (this.secondaryShots){//will choose a random pattern on the 9 points available depends of the numbers of points wanted
-				case 3:
-					if (random <= 25)
-					{
-						this.aShots.push(coords[0][0]);
-						this.aShots.push(coords[1][1]);
-						this.aShots.push(coords[2][2]);
-					}
-					else if (random <= 50)
-					{
-						this.aShots.push(coords[0][2]);
-						this.aShots.push(coords[1][1]);
-						this.aShots.push(coords[2][0]);
-					}
-					else if (random <= 75)
-					{
-						this.aShots.push(coords[1][0]);
-						this.aShots.push(coords[1][1]);
-						this.aShots.push(coords[1][2]);
-					}
-					else if (random <= 100)
-					{
-						this.aShots.push(coords[0][1]);
-						this.aShots.push(coords[1][1]);
-						this.aShots.push(coords[2][1]);
-					}
-					break;
-				case 4:
-					if (random <= 50) {
-						this.aShots.push(coords[0][0]);
-						this.aShots.push(coords[2][0]);
-						this.aShots.push(coords[0][2]);
-						this.aShots.push(coords[2][2]);
-					}
-					else if (random <= 100){
-						this.aShots.push(coords[1][0]);
-						this.aShots.push(coords[0][1]);
-						this.aShots.push(coords[2][1]);
-						this.aShots.push(coords[1][2]);
-					}
-					break;
-				case 5:
-					if (random <= 50) {
-						this.aShots.push(coords[0][0]);
-						this.aShots.push(coords[2][0]);
-						this.aShots.push(coords[0][2]);
-						this.aShots.push(coords[2][2]);
-						this.aShots.push(coords[1][1]);
-					}
-					else if (random <= 100){
-						this.aShots.push(coords[1][0]);
-						this.aShots.push(coords[0][1]);
-						this.aShots.push(coords[2][1]);
-						this.aShots.push(coords[1][2]);
-						this.aShots.push(coords[1][1]);
-					}
-					break;
-				case 6:
-					if (random <= 50) {
-						this.aShots.push(coords[0][0]);
-						this.aShots.push(coords[1][0]);
-						this.aShots.push(coords[2][0]);
-						this.aShots.push(coords[0][2]);
-						this.aShots.push(coords[1][2]);
-						this.aShots.push(coords[2][2]);
-					}
-					else if (random <= 100){
-						this.aShots.push(coords[0][0]);
-						this.aShots.push(coords[0][1]);
-						this.aShots.push(coords[0][2]);
-						this.aShots.push(coords[2][2]);
-						this.aShots.push(coords[2][2]);
-						this.aShots.push(coords[2][2]);
-					}
-					break;
-				case 7:
-					if (random <= 50) {
-						this.aShots.push(coords[0][0]);
-						this.aShots.push(coords[1][0]);
-						this.aShots.push(coords[2][0]);
-						this.aShots.push(coords[0][2]);
-						this.aShots.push(coords[1][2]);
-						this.aShots.push(coords[2][2]);
-						this.aShots.push(coords[1][1]);
-					}
-					else if (random <= 100){
-						this.aShots.push(coords[0][0]);
-						this.aShots.push(coords[0][1]);
-						this.aShots.push(coords[0][2]);
-						this.aShots.push(coords[2][0]);
-						this.aShots.push(coords[2][1]);
-						this.aShots.push(coords[2][2]);
-						this.aShots.push(coords[1][1]);
-					}
-					break;
-				case 8:
-					this.aShots.push(coords[0][0]);
-					this.aShots.push(coords[0][1]);
-					this.aShots.push(coords[0][2]);
-					this.aShots.push(coords[1][0]);
-					this.aShots.push(coords[1][2]);
-					this.aShots.push(coords[2][0]);
-					this.aShots.push(coords[2][1]);
-					this.aShots.push(coords[2][2]);
-					break;
-				case 9:
-					this.aShots.push(coords[0][0]);
-					this.aShots.push(coords[0][1]);
-					this.aShots.push(coords[0][2]);
-					this.aShots.push(coords[1][0]);
-					this.aShots.push(coords[1][1]);
-					this.aShots.push(coords[1][2]);
-					this.aShots.push(coords[2][0]);
-					this.aShots.push(coords[2][1]);
-					this.aShots.push(coords[2][2]);
-					break;
-			}
-		}
-	},
+    getCoordsBoundaries() {
+        return {
+            minLat: this.target.pos.lat <= this.secondaryTarget.pos.lat ? this.target.pos.lat : this.secondaryTarget.pos.lat,
+            maxLat: this.target.pos.lat > this.secondaryTarget.pos.lat ? this.target.pos.lat : this.secondaryTarget.pos.lat,
+            minLng: this.target.pos.lng <= this.secondaryTarget.pos.lng ? this.target.pos.lng : this.secondaryTarget.pos.lng,
+            maxLng: this.target.pos.lng > this.secondaryTarget.pos.lng ? this.target.pos.lng : this.secondaryTarget.pos.lng,
+        };
+    },
+    calcShots() {
+        if (this.tTypeIndex == TARGET_TYPE.LINE)
+        {
+            const interval = this.secondaryShots - 2;
+            const boundaries = this.getCoordsBoundaries();
+            const latVariation = (boundaries.maxLat - boundaries.minLat) / (interval + 1);
+            const lngVariation = (boundaries.maxLng - boundaries.minLng) / (interval + 1);
+
+            this.aShots = [];
+            this.aShots.push({
+                bearing: this.formatDOMBearing(this.c.bearing),
+                elevation: this.formatDOMElevation(this.c.elevation)
+            });//First shot is fixed
+
+            const point = {};
+            let coord;
+            for (let i = 1; i <= interval; i++)//Interval shots are computed
+            {
+                point.pos = new LatLng(boundaries.minLat + (latVariation * i), boundaries.minLng + (lngVariation * i), );
+                coord = this.coordMortar(this.mortar, point);
+                this.aShots.push({
+                    bearing: this.formatDOMBearing(coord.bearing),
+                    elevation: this.formatDOMElevation(coord.elevation)
+                });
+            }
+
+            this.aShots.push({
+                bearing: this.formatDOMBearing(this.c2.bearing),
+                elevation: this.formatDOMElevation(this.c2.elevation)
+            });//Last shot is fixed
+            console.log("calcShots", this.shots);
+        }
+        if (this.tTypeIndex == TARGET_TYPE.AREA)
+        {
+            this.aShots = [];
+            const interval = 3;
+            const boundaries = this.getCoordsBoundaries();
+            const latVariation = (boundaries.maxLat - boundaries.minLat) / (interval + 1);
+            const lngVariation = (boundaries.maxLng - boundaries.minLng) / (interval + 1);
+
+            const latitudes = [];
+            const longitudes = [];
+            for (let i = 1; i <= interval; i++)
+            {
+                latitudes.push(boundaries.minLat + (latVariation * i));
+                longitudes.push(boundaries.minLng + (lngVariation * i));
+            }
+            const coords = [];
+            const point = {};
+            let coord;
+            for (let i = 0; i < interval; i++)
+            {
+                for (let j = 0; j < interval; j++)
+                {
+                    point.pos = new LatLng(latitudes[i], longitudes[j]);
+                    coord = this.coordMortar(this.mortar, point);
+                    if (coords[i] === undefined)
+                        coords[i] = [];
+                    coords[i][j] = {
+                        bearing: this.formatDOMBearing(coord.bearing),
+                        elevation: this.formatDOMElevation(coord.elevation)
+                    };
+                }
+            }
+            const random = Math.floor(Math.random() * Math.floor(100));// get random value between 0-100
+            switch (this.secondaryShots){//will choose a random pattern on the 9 points available depends of the numbers of points wanted
+                case 3:
+                    if (random <= 25)
+                    {
+                        this.aShots.push(coords[0][0]);
+                        this.aShots.push(coords[1][1]);
+                        this.aShots.push(coords[2][2]);
+                    }
+                    else if (random <= 50)
+                    {
+                        this.aShots.push(coords[0][2]);
+                        this.aShots.push(coords[1][1]);
+                        this.aShots.push(coords[2][0]);
+                    }
+                    else if (random <= 75)
+                    {
+                        this.aShots.push(coords[1][0]);
+                        this.aShots.push(coords[1][1]);
+                        this.aShots.push(coords[1][2]);
+                    }
+                    else if (random <= 100)
+                    {
+                        this.aShots.push(coords[0][1]);
+                        this.aShots.push(coords[1][1]);
+                        this.aShots.push(coords[2][1]);
+                    }
+                    break;
+                case 4:
+                    if (random <= 50) {
+                        this.aShots.push(coords[0][0]);
+                        this.aShots.push(coords[2][0]);
+                        this.aShots.push(coords[0][2]);
+                        this.aShots.push(coords[2][2]);
+                    }
+                    else if (random <= 100){
+                        this.aShots.push(coords[1][0]);
+                        this.aShots.push(coords[0][1]);
+                        this.aShots.push(coords[2][1]);
+                        this.aShots.push(coords[1][2]);
+                    }
+                    break;
+                case 5:
+                    if (random <= 50) {
+                        this.aShots.push(coords[0][0]);
+                        this.aShots.push(coords[2][0]);
+                        this.aShots.push(coords[0][2]);
+                        this.aShots.push(coords[2][2]);
+                        this.aShots.push(coords[1][1]);
+                    }
+                    else if (random <= 100){
+                        this.aShots.push(coords[1][0]);
+                        this.aShots.push(coords[0][1]);
+                        this.aShots.push(coords[2][1]);
+                        this.aShots.push(coords[1][2]);
+                        this.aShots.push(coords[1][1]);
+                    }
+                    break;
+                case 6:
+                    if (random <= 50) {
+                        this.aShots.push(coords[0][0]);
+                        this.aShots.push(coords[1][0]);
+                        this.aShots.push(coords[2][0]);
+                        this.aShots.push(coords[0][2]);
+                        this.aShots.push(coords[1][2]);
+                        this.aShots.push(coords[2][2]);
+                    }
+                    else if (random <= 100){
+                        this.aShots.push(coords[0][0]);
+                        this.aShots.push(coords[0][1]);
+                        this.aShots.push(coords[0][2]);
+                        this.aShots.push(coords[2][2]);
+                        this.aShots.push(coords[2][2]);
+                        this.aShots.push(coords[2][2]);
+                    }
+                    break;
+                case 7:
+                    if (random <= 50) {
+                        this.aShots.push(coords[0][0]);
+                        this.aShots.push(coords[1][0]);
+                        this.aShots.push(coords[2][0]);
+                        this.aShots.push(coords[0][2]);
+                        this.aShots.push(coords[1][2]);
+                        this.aShots.push(coords[2][2]);
+                        this.aShots.push(coords[1][1]);
+                    }
+                    else if (random <= 100){
+                        this.aShots.push(coords[0][0]);
+                        this.aShots.push(coords[0][1]);
+                        this.aShots.push(coords[0][2]);
+                        this.aShots.push(coords[2][0]);
+                        this.aShots.push(coords[2][1]);
+                        this.aShots.push(coords[2][2]);
+                        this.aShots.push(coords[1][1]);
+                    }
+                    break;
+                case 8:
+                    this.aShots.push(coords[0][0]);
+                    this.aShots.push(coords[0][1]);
+                    this.aShots.push(coords[0][2]);
+                    this.aShots.push(coords[1][0]);
+                    this.aShots.push(coords[1][2]);
+                    this.aShots.push(coords[2][0]);
+                    this.aShots.push(coords[2][1]);
+                    this.aShots.push(coords[2][2]);
+                    break;
+                case 9:
+                    this.aShots.push(coords[0][0]);
+                    this.aShots.push(coords[0][1]);
+                    this.aShots.push(coords[0][2]);
+                    this.aShots.push(coords[1][0]);
+                    this.aShots.push(coords[1][1]);
+                    this.aShots.push(coords[1][2]);
+                    this.aShots.push(coords[2][0]);
+                    this.aShots.push(coords[2][1]);
+                    this.aShots.push(coords[2][2]);
+                    break;
+            }
+        }
+    },
     /**
      * Remove an already placed mortar, specified by its index in placedMortars
      * @param {Number} i - index of mortar in placedMortars
@@ -1259,24 +1259,24 @@ export default {
       if (tTarget === this.target) {
         if (this.placedTargets.length > 0) {
           this.target = this.placedTargets[i === 0 ? 0 : i - 1];
-		  if (this.target.pUrl == this.secondaryTarget.pUrl)
-			this.secondaryTarget = undefined;
+          if (this.target.pUrl == this.secondaryTarget.pUrl)
+            this.secondaryTarget = undefined;
         } else {
           this.target = undefined;
-		  this.secondaryTarget = undefined;
+          this.secondaryTarget = undefined;
         }
       }
       tTarget.removeFrom(this.map);
     },
-	formatDOMElevation(elevation) {
-		if (Number.isNaN(elevation) || elevation > 1580 || elevation < 800) {
-			return "∠XXXX.Xmil";
-		}
+    formatDOMElevation(elevation) {
+      if (Number.isNaN(elevation) || elevation > 1580 || elevation < 800) {
+        return "∠XXXX.Xmil";
+      }
       return `∠${pad((Math.round(elevation * 10) / 10).toFixed(1), 6)}mil`;
-	},
-	formatDOMBearing(bearing) {
-		return `✵${pad((Math.round(bearing * 10) / 10).toFixed(1), 5)}°`;
-	},
+    },
+    formatDOMBearing(bearing) {
+      return `✵${pad((Math.round(bearing * 10) / 10).toFixed(1), 5)}°`;
+    },
     /**
      * Remove an already placed fob, specified by its index in placedFobs
      * @param {Number} i - index of fob in placedFobs
@@ -1333,13 +1333,13 @@ export default {
     openGitHub() {
       window.open("https://github.com/Endebert/squadmc", "_blank");
     },
-	clearSecondaryLines() {
-		if (this.secondaryLine !== undefined)
-		{
-			this.map.removeLayer(this.secondaryLine);
-			this.secondaryLine = undefined;
-		}
-	},
+    clearSecondaryLines() {
+      if (this.secondaryLine !== undefined)
+      {
+        this.map.removeLayer(this.secondaryLine);
+        this.secondaryLine = undefined;
+      }
+    },
 
     /**
      * This function works in tandem with showHeightmap watcher.
@@ -1367,12 +1367,13 @@ export default {
     },
     onDragEndListener() {
       this.dragging = false;
-      if (this.mortar && this.target) 
-	  { 
-		this.calcMortar(this.mortar, this.target, false);
-		if (this.secondaryTarget)
-			this.calcMortarSecondary(this.mortar, this.secondaryTarget, false);
-	  }
+      if (this.mortar && this.target)
+      {
+        this.calcMortar(this.mortar, this.target, false);
+        if (this.secondaryTarget) {
+            this.calcMortarSecondary(this.mortar, this.secondaryTarget, false);
+		}
+      }
     },
 
     /**
@@ -1473,7 +1474,7 @@ export default {
       console.log("mortarPosWatcher");
       if (this.mortar && this.target) {
         this.calcMortar(this.mortar, this.target, this.delayCalcUpdate);
-		this.calcMortarSecondary(this.mortar, this.secondaryTarget, this.delayCalcUpdate);
+        this.calcMortarSecondary(this.mortar, this.secondaryTarget, this.delayCalcUpdate);
       } else if (this.map.hasLayer(this.distLine)) {
         this.map.removeLayer(this.distLine);
       }
@@ -1485,19 +1486,19 @@ export default {
       console.log("targetPosWatcher");
       if (this.mortar && this.target) {
         this.calcMortar(this.mortar, this.target, this.delayCalcUpdate);
-		this.drawSecondaryLine();
+        this.drawSecondaryLine();
       } else if (this.map.hasLayer(this.distLine)) {
         this.map.removeLayer(this.distLine);
       }
     },
-	"secondaryTarget.pos" : function secondaryTargetPosWatcher() {
-		console.log("secondaryTargetPosWatcher");
-		if (this.mortar && this.target && this.secondaryTarget) {
-			this.calcMortarSecondary(this.mortar, this.secondaryTarget, this.delayCalcUpdate);
-		} else {
-			this.clearSecondaryLines();
+    "secondaryTarget.pos" : function secondaryTargetPosWatcher() {
+        console.log("secondaryTargetPosWatcher");
+        if (this.mortar && this.target && this.secondaryTarget) {
+            this.calcMortarSecondary(this.mortar, this.secondaryTarget, this.delayCalcUpdate);
+        } else {
+            this.clearSecondaryLines();
       }
-	},
+    },
     /**
      * let new active mortar know that it is active now (in order to show min and max range circles)
      * @param {PinHolder} newM - new active mortar
@@ -1514,13 +1515,13 @@ export default {
         newM.setActive(true, this.map);
       }
     },
-	secondaryShots(i) {
-		this.toStorage("secondaryShots", i);
-		if (this.advancedMode && this.target && this.secondaryTarget && this.tTypeIndex > TARGET_TYPE.POINT)
-		{
-			this.calcShots();
-		}
-	},
+    secondaryShots(i) {
+        this.toStorage("secondaryShots", i);
+        if (this.advancedMode && this.target && this.secondaryTarget && this.tTypeIndex > TARGET_TYPE.POINT)
+        {
+            this.calcShots();
+        }
+    },
     /**
      * Resets map when advancedMode is disabled (fixes orphaned markers)
      * @param {Boolean} b - advancedMode state boolean
@@ -1535,8 +1536,8 @@ export default {
         while (this.placedTargets.length > 0) {
           this.removeTarget(0);
         }
-		//set targetType to point
-		this.tTypeIndex = 0;
+        //set targetType to point
+        this.tTypeIndex = 0;
       }
       this.toStorage("advancedMode", b);
     },
@@ -1591,16 +1592,16 @@ export default {
     hideLoadingBar(b) {
       this.toStorage("hideLoadingBar", b);
     },
-	tTypeIndex(newIndex) {
-		this.toStorage("tTypeIndex", newIndex);
-		this.placedTargets.forEach((marker) => {
-			if (marker.sUrl != this.target.sUrl)
-			{
-				this.secondaryTarget = marker;
-			}
-		});
-		this.drawSecondaryLine();
-	},
+    tTypeIndex(newIndex) {
+        this.toStorage("tTypeIndex", newIndex);
+        this.placedTargets.forEach((marker) => {
+            if (marker.sUrl != this.target.sUrl)
+            {
+                this.secondaryTarget = marker;
+            }
+        });
+        this.drawSecondaryLine();
+    },
 
     /* PostScriptum exclusive */
 
@@ -1634,7 +1635,7 @@ export default {
      * @return {String} formatted string
      */
     DOMelevation() {
-		return this.formatDOMElevation(this.c.elevation);
+        return this.formatDOMElevation(this.c.elevation);
     },
     /**
      * Returns formatted dist string for DOM element
@@ -1653,22 +1654,22 @@ export default {
       }
       return `↕-${pad(Math.round(-this.c.hDelta), 3)}m`;
     },
-	
-	DOMminbearing() {
-		const minBearing = this.c.bearing <= this.c2.bearing ? this.c.bearing : this.c2.bearing;
-		return this.formatDOMBearing(minBearing);
-	},
-	
-	DOMmaxbearing() {
-		const maxBearing = this.c.bearing >= this.c2.bearing ? this.c.bearing : this.c2.bearing;
-		return this.formatDOMBearing(maxBearing);
-	},
-	DOMminelevation() {
-	  const minElevation = this.c.elevation <= this.c2.elevation ? this.c.elevation : this.c2.elevation;
+
+    DOMminbearing() {
+        const minBearing = this.c.bearing <= this.c2.bearing ? this.c.bearing : this.c2.bearing;
+        return this.formatDOMBearing(minBearing);
+    },
+
+    DOMmaxbearing() {
+        const maxBearing = this.c.bearing >= this.c2.bearing ? this.c.bearing : this.c2.bearing;
+        return this.formatDOMBearing(maxBearing);
+    },
+    DOMminelevation() {
+      const minElevation = this.c.elevation <= this.c2.elevation ? this.c.elevation : this.c2.elevation;
       return this.formatDOMElevation(minElevation);
     },
-	DOMmaxelevation() {
-	  const maxElevation = this.c.elevation >= this.c2.elevation ? this.c.elevation : this.c2.elevation;
+    DOMmaxelevation() {
+      const maxElevation = this.c.elevation >= this.c2.elevation ? this.c.elevation : this.c2.elevation;
       return this.formatDOMElevation(maxElevation);
     },
 
@@ -1681,9 +1682,9 @@ export default {
     currentMType() {
       return this.mortarTypes[this.mTypeIndex];
     },
-	currentTType() {
-		return this.targetTypes[this.tTypeIndex];
-	}
+    currentTType() {
+        return this.targetTypes[this.tTypeIndex];
+    }
   },
 };
 </script>

--- a/src/Map.vue
+++ b/src/Map.vue
@@ -258,7 +258,7 @@
   <v-content class="fixedPos">
     <div id="map" class="fixedPos"></div>
   </v-content>
-  <v-content class="fixedPos" style="pointer-events: none" >
+  <v-content class="fixedPos" style="pointer-events: none;" >
     <div class="bottom-bar front" style="pointer-events: none;">
       <div style="display: flex; align-items: flex-end">
         <div class="ma-2 px-1 secondary font-mono" style="width: fit-content; flex: 0 1 auto"
@@ -327,7 +327,7 @@
           </v-dialog>
         </div>
       </div>
-      <div id="my-footer" v-if="mortar && target && secondaryTarget == undefined" style="background-color: #212121">
+      <div id="my-footer" v-if="mortar && target && secondaryTarget == undefined" style="background-color: #212121;">
         <v-speed-dial>
           <v-btn fab small slot="activator" class="secondary" style="width: 32px; height: 32px;">
             <img :src="mortar.sUrl" style="width: 48px;">
@@ -372,7 +372,7 @@
       </div>
       <div id="my-footer"
         v-if="mortar && target && tTypeIndex > TARGET_TYPE.POINT && secondaryTarget"
-        style="background-color: #212121">
+        style="background-color: #212121;">
         <v-speed-dial>
           <v-btn fab small slot="activator" class="secondary"
             style="width: 32px; height: 32px; margin-left: 4px; margin-right: 4px;">
@@ -434,24 +434,30 @@
           </div>
         </div>
       </div>
-      <div class="flex" style="flex;background-color: #212121">
-        <div class="font-mono flex column"
-          v-if="tTypeIndex > TARGET_TYPE.POINT && secondaryTarget" v-for="(aShot, index) in aShots" :key="index">
-          <div class="flex" style="width: 100%;">
+      <div id="my-subtargets" class="flex" style="flex;background-color: #212121; align-items: center;"
+        v-if="aSubTargets.length > 0">
+        <div class="flex" v-if="currentSubTarget > 0">
+          <v-icon @click="currentSubTarget--">keyboard_arrow_left</v-icon>
+        </div>
+        <div class="font-mono flex column" style="flex-grow: 1;">
+          <div class="flex">
             <div class="px-1" style="flex: 1 0 auto; text-align: center; font-size: small">
-                Round {{index + 1}}
+                Round {{ currentSubTarget + 1 }} / {{ secondaryShots }}
           </div>
           </div>
-          <div class="flex" style="width: 100%;">
+          <div class="flex">
             <div class="px-1" style="flex: 1 0 auto; text-align: center; font-size: small">
-                {{ aShot.bearing }}
+                {{ aSubTargets[currentSubTarget].bearing }}
             </div>
           </div>
-          <div class="flex" style="width: 100%;">
+          <div class="flex">
             <div class="px-1" style="flex: 1 0 auto; text-align: center; font-size: small">
-                {{ aShot.elevation }}
+                {{ aSubTargets[currentSubTarget].elevation }}
             </div>
           </div>
+        </div>
+        <div class="flex" v-if="currentSubTarget < aSubTargets.length - 1">
+          <v-icon @click="currentSubTarget++">keyboard_arrow_right</v-icon>
         </div>
       </div>
     </div>
@@ -594,7 +600,8 @@ export default {
       secondaryShots: Number.parseInt(this.fromStorage("secondaryShots", "5"), 10),
       distLine: undefined, // the line
       secondaryLine: undefined, // The secondary line
-      aShots: [], // values of intermediary shots (for line and area target)
+      aSubTargets: [], // values of intermediary shots (for line and area target)
+      currentSubTarget: Number.parseInt(this.fromStorage("currentSubTarget", "0"), 10),
       // available colors
       colors: {
         pin: {
@@ -1085,8 +1092,8 @@ export default {
         const latVariation = (boundaries.maxLat - boundaries.minLat) / (interval + 1);
         const lngVariation = (boundaries.maxLng - boundaries.minLng) / (interval + 1);
 
-        this.aShots = [];
-        this.aShots.push({
+        this.aSubTargets = [];
+        this.aSubTargets.push({
           bearing: this.formatDOMBearing(this.c.bearing),
           elevation: this.formatDOMElevation(this.c.elevation),
         });// First shot is fixed
@@ -1096,20 +1103,20 @@ export default {
         for (let i = 1; i <= interval; i++) { // Interval shots are computed
           point.pos = new LatLng(boundaries.minLat + (latVariation * i), boundaries.minLng + (lngVariation * i));
           coord = this.coordMortar(this.mortar, point);
-          this.aShots.push({
+          this.aSubTargets.push({
             bearing: this.formatDOMBearing(coord.bearing),
             elevation: this.formatDOMElevation(coord.elevation),
           });
         }
 
-        this.aShots.push({
+        this.aSubTargets.push({
           bearing: this.formatDOMBearing(this.c2.bearing),
           elevation: this.formatDOMElevation(this.c2.elevation),
         });// Last shot is fixed
         console.log("calcShots", this.shots);
       }
       if (this.tTypeIndex === TARGET_TYPE.AREA) {
-        this.aShots = [];
+        this.aSubTargets = [];
         const interval = 3;
         const boundaries = this.getCoordsBoundaries();
         const latVariation = (boundaries.maxLat - boundaries.minLat) / (interval + 1);
@@ -1142,108 +1149,108 @@ export default {
         switch (this.secondaryShots) {
           case 3:
             if (random <= 25) {
-              this.aShots.push(coords[0][0]);
-              this.aShots.push(coords[1][1]);
-              this.aShots.push(coords[2][2]);
+              this.aSubTargets.push(coords[0][0]);
+              this.aSubTargets.push(coords[1][1]);
+              this.aSubTargets.push(coords[2][2]);
             } else if (random <= 50) {
-              this.aShots.push(coords[0][2]);
-              this.aShots.push(coords[1][1]);
-              this.aShots.push(coords[2][0]);
+              this.aSubTargets.push(coords[0][2]);
+              this.aSubTargets.push(coords[1][1]);
+              this.aSubTargets.push(coords[2][0]);
             } else if (random <= 75) {
-              this.aShots.push(coords[1][0]);
-              this.aShots.push(coords[1][1]);
-              this.aShots.push(coords[1][2]);
+              this.aSubTargets.push(coords[1][0]);
+              this.aSubTargets.push(coords[1][1]);
+              this.aSubTargets.push(coords[1][2]);
             } else if (random <= 100) {
-              this.aShots.push(coords[0][1]);
-              this.aShots.push(coords[1][1]);
-              this.aShots.push(coords[2][1]);
+              this.aSubTargets.push(coords[0][1]);
+              this.aSubTargets.push(coords[1][1]);
+              this.aSubTargets.push(coords[2][1]);
             }
             break;
           case 4:
             if (random <= 50) {
-              this.aShots.push(coords[0][0]);
-              this.aShots.push(coords[2][0]);
-              this.aShots.push(coords[0][2]);
-              this.aShots.push(coords[2][2]);
+              this.aSubTargets.push(coords[0][0]);
+              this.aSubTargets.push(coords[2][0]);
+              this.aSubTargets.push(coords[0][2]);
+              this.aSubTargets.push(coords[2][2]);
             } else if (random <= 100) {
-              this.aShots.push(coords[1][0]);
-              this.aShots.push(coords[0][1]);
-              this.aShots.push(coords[2][1]);
-              this.aShots.push(coords[1][2]);
+              this.aSubTargets.push(coords[1][0]);
+              this.aSubTargets.push(coords[0][1]);
+              this.aSubTargets.push(coords[2][1]);
+              this.aSubTargets.push(coords[1][2]);
             }
             break;
           default:
           case 5:
             if (random <= 50) {
-              this.aShots.push(coords[0][0]);
-              this.aShots.push(coords[2][0]);
-              this.aShots.push(coords[0][2]);
-              this.aShots.push(coords[2][2]);
-              this.aShots.push(coords[1][1]);
+              this.aSubTargets.push(coords[0][0]);
+              this.aSubTargets.push(coords[2][0]);
+              this.aSubTargets.push(coords[0][2]);
+              this.aSubTargets.push(coords[2][2]);
+              this.aSubTargets.push(coords[1][1]);
             } else if (random <= 100) {
-              this.aShots.push(coords[1][0]);
-              this.aShots.push(coords[0][1]);
-              this.aShots.push(coords[2][1]);
-              this.aShots.push(coords[1][2]);
-              this.aShots.push(coords[1][1]);
+              this.aSubTargets.push(coords[1][0]);
+              this.aSubTargets.push(coords[0][1]);
+              this.aSubTargets.push(coords[2][1]);
+              this.aSubTargets.push(coords[1][2]);
+              this.aSubTargets.push(coords[1][1]);
             }
             break;
           case 6:
             if (random <= 50) {
-              this.aShots.push(coords[0][0]);
-              this.aShots.push(coords[1][0]);
-              this.aShots.push(coords[2][0]);
-              this.aShots.push(coords[0][2]);
-              this.aShots.push(coords[1][2]);
-              this.aShots.push(coords[2][2]);
+              this.aSubTargets.push(coords[0][0]);
+              this.aSubTargets.push(coords[1][0]);
+              this.aSubTargets.push(coords[2][0]);
+              this.aSubTargets.push(coords[0][2]);
+              this.aSubTargets.push(coords[1][2]);
+              this.aSubTargets.push(coords[2][2]);
             } else if (random <= 100) {
-              this.aShots.push(coords[0][0]);
-              this.aShots.push(coords[0][1]);
-              this.aShots.push(coords[0][2]);
-              this.aShots.push(coords[2][2]);
-              this.aShots.push(coords[2][2]);
-              this.aShots.push(coords[2][2]);
+              this.aSubTargets.push(coords[0][0]);
+              this.aSubTargets.push(coords[0][1]);
+              this.aSubTargets.push(coords[0][2]);
+              this.aSubTargets.push(coords[2][2]);
+              this.aSubTargets.push(coords[2][2]);
+              this.aSubTargets.push(coords[2][2]);
             }
             break;
           case 7:
             if (random <= 50) {
-              this.aShots.push(coords[0][0]);
-              this.aShots.push(coords[1][0]);
-              this.aShots.push(coords[2][0]);
-              this.aShots.push(coords[0][2]);
-              this.aShots.push(coords[1][2]);
-              this.aShots.push(coords[2][2]);
-              this.aShots.push(coords[1][1]);
+              this.aSubTargets.push(coords[0][0]);
+              this.aSubTargets.push(coords[1][0]);
+              this.aSubTargets.push(coords[2][0]);
+              this.aSubTargets.push(coords[0][2]);
+              this.aSubTargets.push(coords[1][2]);
+              this.aSubTargets.push(coords[2][2]);
+              this.aSubTargets.push(coords[1][1]);
             } else if (random <= 100) {
-              this.aShots.push(coords[0][0]);
-              this.aShots.push(coords[0][1]);
-              this.aShots.push(coords[0][2]);
-              this.aShots.push(coords[2][0]);
-              this.aShots.push(coords[2][1]);
-              this.aShots.push(coords[2][2]);
-              this.aShots.push(coords[1][1]);
+              this.aSubTargets.push(coords[0][0]);
+              this.aSubTargets.push(coords[0][1]);
+              this.aSubTargets.push(coords[0][2]);
+              this.aSubTargets.push(coords[2][0]);
+              this.aSubTargets.push(coords[2][1]);
+              this.aSubTargets.push(coords[2][2]);
+              this.aSubTargets.push(coords[1][1]);
             }
             break;
           case 8:
-            this.aShots.push(coords[0][0]);
-            this.aShots.push(coords[0][1]);
-            this.aShots.push(coords[0][2]);
-            this.aShots.push(coords[1][0]);
-            this.aShots.push(coords[1][2]);
-            this.aShots.push(coords[2][0]);
-            this.aShots.push(coords[2][1]);
-            this.aShots.push(coords[2][2]);
+            this.aSubTargets.push(coords[0][0]);
+            this.aSubTargets.push(coords[0][1]);
+            this.aSubTargets.push(coords[0][2]);
+            this.aSubTargets.push(coords[1][0]);
+            this.aSubTargets.push(coords[1][2]);
+            this.aSubTargets.push(coords[2][0]);
+            this.aSubTargets.push(coords[2][1]);
+            this.aSubTargets.push(coords[2][2]);
             break;
           case 9:
-            this.aShots.push(coords[0][0]);
-            this.aShots.push(coords[0][1]);
-            this.aShots.push(coords[0][2]);
-            this.aShots.push(coords[1][0]);
-            this.aShots.push(coords[1][1]);
-            this.aShots.push(coords[1][2]);
-            this.aShots.push(coords[2][0]);
-            this.aShots.push(coords[2][1]);
-            this.aShots.push(coords[2][2]);
+            this.aSubTargets.push(coords[0][0]);
+            this.aSubTargets.push(coords[0][1]);
+            this.aSubTargets.push(coords[0][2]);
+            this.aSubTargets.push(coords[1][0]);
+            this.aSubTargets.push(coords[1][1]);
+            this.aSubTargets.push(coords[1][2]);
+            this.aSubTargets.push(coords[2][0]);
+            this.aSubTargets.push(coords[2][1]);
+            this.aSubTargets.push(coords[2][2]);
             break;
         }
       }
@@ -1279,15 +1286,21 @@ export default {
           this.target = this.placedTargets[i === 0 ? 0 : i - 1];
           if (this.target.pUrl === this.secondaryTarget.pUrl) {
             this.secondaryTarget = undefined;
+            this.aSubTargets = [];
+            this.currentSubTarget = 0;
             this.drawSecondaryLine();
           }
         } else {
           this.target = undefined;
           this.secondaryTarget = undefined;
+          this.aSubTargets = [];
+          this.currentSubTarget = 0;
           this.drawSecondaryLine();
         }
       } else if (tTarget === this.secondaryTarget) {
         this.secondaryTarget = undefined;
+        this.aSubTargets = [];
+        this.currentSubTarget = 0;
         this.drawSecondaryLine();
       }
       tTarget.removeFrom(this.map);
@@ -1623,6 +1636,10 @@ export default {
       this.drawSecondaryLine();
     },
 
+    currentSubTarget(i) {
+      this.toStorage("currentSubTarget", i);
+    },
+
     /* PostScriptum exclusive */
 
     /**
@@ -1790,7 +1807,7 @@ body::-webkit-scrollbar {
   height: 100%;
 }
 
-#my-footer {
+#my-footer, #my-subtargets {
   display: flex; align-items: center; pointer-events: all
 }
 

--- a/src/assets/Vars.js
+++ b/src/assets/Vars.js
@@ -21,11 +21,20 @@ export const PIN_TYPE = Object.freeze({
   TARGET: 1,
   FOB: 2,
 });
-export const TARGET_TYPE =  Object.freeze({
+export const TARGET_TYPE = Object.freeze({
   POINT: 0,
   LINE: 1,
   AREA: 2,
 });
+export const SUBTARGET_RADIUS = [
+  100,
+  80,
+  50,
+  35,
+  12,
+  5,
+  3,
+];
 const PIN_MAP = {};
 PIN_MAP[PIN_TYPE.MORTAR] = [
   ["/img/svg/mortar_pin_red.svg", "/img/svg/mortar_symbol_red.svg", "#F44336"],

--- a/src/assets/Vars.js
+++ b/src/assets/Vars.js
@@ -16,6 +16,7 @@ export const PS_4INCH_MAX_DISTANCE = 2601;
 export const PS_3INCH_MAX_DISTANCE = 1466;
 export const GRAVITY = 9.8;
 export const MIL_TO_DEG_FACTOR = 360 / 6400;
+export const MAX_SUBTARGETS_COUNT = 50;
 export const PIN_TYPE = Object.freeze({
   MORTAR: 0,
   TARGET: 1,
@@ -26,12 +27,19 @@ export const TARGET_TYPE = Object.freeze({
   LINE: 1,
   AREA: 2,
 });
-export const SUBTARGET_RADIUS = [
-  100,
-  80,
+export const SUBTARGET_ROUND_SPACING = [
+  5,
+  10,
+  20,
+  30,
   50,
-  35,
+];
+export const SUBTARGET_RADIUS = [
   12,
+  12,
+  12,
+  10,
+  7,
   5,
   3,
 ];

--- a/src/assets/Vars.js
+++ b/src/assets/Vars.js
@@ -2,7 +2,6 @@
  * Small utility file exporting static values that are reused often
  * @type {number}
  */
-
 export const ICON_SIZE = 48;
 export const MIN_DISTANCE = 50;
 export const FOB_RANGE = 150;
@@ -21,6 +20,11 @@ export const PIN_TYPE = Object.freeze({
   MORTAR: 0,
   TARGET: 1,
   FOB: 2,
+});
+export const TARGET_TYPE =  Object.freeze({
+  POINT: 0,
+  LINE: 1,
+  AREA: 2,
 });
 const PIN_MAP = {};
 PIN_MAP[PIN_TYPE.MORTAR] = [


### PR DESCRIPTION
Hello,

New pull request with cleaned code and a small bug resolved (changing mortar type don't recompute secondary target coordinates)

I added a new useful feature avaiable in advanced mode :
You're able to choose between 3 targetType : POINT, LINE or AREA
POINT mode is the legacy behavior and is selected by default
In LINE or AREA mode, the footer will change to be able to select a secondary target who will act as boundarie.
The footer will mainly show the range of bearing and the range of elevation and will display the precomputed targets.
User can choose a custom amount of precomputed subtargets alongs the line or inside the area (from 3 to 9, default 5).

The behavior of your tool remain unchanged unless you select one of the 2 new feature.
There is a small refactoring who consist to isolate the coordinates computing from calcMortar because it made some drawing tasks which are not required for all computation tasks.

As far as I know the code handle target and mortar add/mode/delete actions and make usage of localstorage to remember user prefs.

I made it under the postscriptum branch but it should works fine on squad branch as there are no dependancy to postscriptum.

Screenshots :
![2018-08-18_020356](https://user-images.githubusercontent.com/2920509/44294168-305b9280-a293-11e8-8a2c-873f9bca8eff.png)
![2018-08-18_020431](https://user-images.githubusercontent.com/2920509/44294171-32bdec80-a293-11e8-921c-ae35bd1e9622.png)
