### PR TITLE
Use modern flag to build production files

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "private": true,
   "scripts": {
     "serve": "vue-cli-service serve",
-    "build": "vue-cli-service build",
+    "build": "vue-cli-service build --modern",
     "lint": "vue-cli-service lint",
     "release": "standard-version"
   },


### PR DESCRIPTION
Added to `--modern` flag to the vue-cli build command.
This way vue cli builds two versions of the production files. One for modern browsers and one for legacy browsers. This reduces bundle sizes for modern browsers significantly.

For more details see https://cli.vuejs.org/guide/browser-compatibility.html#modern-mode