### PR TITLE
fix: fobPin remove error

### DIFF
--- a/src/Map.vue
+++ b/src/Map.vue
@@ -1334,7 +1334,8 @@ export default {
       console.log("removeFob:", i);
       const tFob = this.placedFobs[i];
       this.placedFobs.splice(i, 1);
-      tFob.removeFrom(this.map);
+      tFob.hide()
+      // tFob.removeFrom(this.map);
     },
     /**
      * Try to get item from localStorage, return defVal if it fails or item is not in storage


### PR DESCRIPTION
Hello!

Noticed an error while randomly testing some stuff locally: fob markers cannot be deleted in advanced mode.
Complains about `.removeFrom()` not being a function. 
Noticed that removing markers was probably changed in the past, but fobPin removing was still different than others. I fixed it by calling `.hide()` instead of `.removeFrom()`, like the other markers does.
I guess it's not so often used feature, and only available in advanced mode, that no one really noticed it before.

I just cherry picked this commit from my local test branch and committed it on top of current dev. Hopefully it is okay this time. :sweat_smile: 