### PR TITLE
feat: add 6cm mortar option for PS US airborne faction

### DIFF
--- a/src/assets/Utils.js
+++ b/src/assets/Utils.js
@@ -14,6 +14,7 @@ import {
   PS_4INCH_NAME,
   PS_3INCH_MAX_DISTANCE,
   PS_3INCH_VELOCITY, PS_3INCH_NAME,
+  PS_6CM_NAME, PS_6CM_VELOCITY, PS_6CM_MAX_DISTANCE,
 } from "./Vars";
 import MortarType from "./MortarType";
 
@@ -331,6 +332,7 @@ export function getPSMortarTypes() {
     new MortarType(PS_8CM_NAME, PS_8CM_VELOCITY, PS_8CM_MAX_DISTANCE),
     new MortarType(PS_3INCH_NAME, PS_3INCH_VELOCITY, PS_3INCH_MAX_DISTANCE),
     new MortarType(PS_4INCH_NAME, PS_4INCH_VELOCITY, PS_4INCH_MAX_DISTANCE),
+    new MortarType(PS_6CM_NAME, PS_6CM_VELOCITY, PS_6CM_MAX_DISTANCE),
   ];
 }
 

--- a/src/assets/Vars.js
+++ b/src/assets/Vars.js
@@ -52,6 +52,10 @@ export const PS_4INCH_NAME = "BRIT 4″";
 export const PS_4INCH_VELOCITY = 159.666038;
 export const PS_4INCH_MAX_DISTANCE = 2601;
 
+export const PS_6CM_NAME = "US 6cm";
+export const PS_6CM_VELOCITY = 119.874256;
+export const PS_6CM_MAX_DISTANCE = 1466;
+
 export const GRAVITY = 9.8;
 export const MIL_TO_DEG_FACTOR = 360 / 6400;
 export const MAX_SUBTARGETS_COUNT = 49;


### PR DESCRIPTION
Hey!

US faction 60mm mortar selection for the calculator interface. Named it as USA 6cm, to look similar with German name. (fun fact: mortar was designed by French, hence the metric unit!)

As of currently, it has the same parameters as the British 3" mortar. (same ranging inside the game)
I added it as a new button, but maybe this could be integrated with the same existing button for British 3"  one? (Just had this idea...)
Well, in any case, quite minor changes to the existing code and I suppose it's question of taste, how to implement it. 😃