### PR TITLE
fix: Added cache-control immutable header

### DIFF
--- a/public/_headers
+++ b/public/_headers
@@ -2,7 +2,7 @@
 ## Set required http headers for hsts and disable cache revalidation
 /*
   Strict-Transport-Security: max-age=31536000; includeSubDomains; preload
-  Cache-Control: public, max-age=6480000
+  Cache-Control: public, max-age=6480000, immutable
 
 ## Index should always revalidate
 /index.html


### PR DESCRIPTION
While it works fine without this header in Chrome, this is needed for Firefox to cache without re-validation.