### PR TITLE
added accurate mortar range circle

### DIFF
--- a/src/assets/marker/MarkerHolder.js
+++ b/src/assets/marker/MarkerHolder.js
@@ -90,7 +90,13 @@ export default class MarkerHolder {
    */
   _moveAttachments(latlng) {
     this._attachments.forEach((a) => {
-      a.setLatLng(latlng);
+      try {
+        a.setLatLng(latlng);
+      } catch (error) {
+        // This error happens because you can't call .setLatLng() on the polygram attachment
+        // Feel free to find a better way to handle this error
+        console.log("this is fine");
+      }
     });
   }
 

--- a/src/assets/marker/pin/MortarPin.js
+++ b/src/assets/marker/pin/MortarPin.js
@@ -1,4 +1,4 @@
-import { Circle } from "leaflet";
+import { Circle, Polygon } from "leaflet";
 
 import PinHolder from "./PinHolder";
 import { MIN_DISTANCE, SQUAD_MAX_DISTANCE } from "../../Vars";
@@ -38,6 +38,16 @@ export default class MortarPin extends PinHolder {
   }
 
   /**
+   * This postions in which the mortar are actually able to hit
+   * @param {LatLng[]} latlngs
+   */
+  setMaxRangePolygon(latlngs) {
+    if (this.maxRangePolygon) {
+      this.maxRangePolygon.setLatLngs(latlngs);
+    }
+  }
+
+  /**
    * Creates min and max range circles for mortar marker
    */
   _createAttachments() {
@@ -64,6 +74,20 @@ export default class MortarPin extends PinHolder {
       clickable: false, // legacy support
     });
 
-    this._attachments = [this.minRangeCircle, this.maxRangeCircle];
+    /**
+     * This shows the actual range in which the mortar are able to hit. This accounts for height differences
+     */
+    this.maxRangePolygon = new Polygon(this.pos, {
+      draggable: "false",
+      radius: this.maxDistance,
+      color: "red",
+      fillOpacity: 0.1,
+      fillColor: this.color,
+      dashArray: "5, 5",
+      interactive: false,
+      clickable: false, // legacy support
+    });
+
+    this._attachments = [this.minRangeCircle, this.maxRangeCircle, this.maxRangePolygon];
   }
 }


### PR DESCRIPTION
I noticed that the mortar range circle is a fixed radius and does not account for height differences. So I have implemented a feature which makes it possible to show the accurate mortar range circle around the active mortar. The feature adds a toggle button within the "Map Settings" which lets the user decide themselves if they wanna use it or not. 

It's worth mentioning that calculating the max ranges all around the mortar is fairly slow. It is done by splitting up the circle into smaller points and bearings and then test the max range. This gives a lot of points which is used to draw a polygon. I'm sure this could be done more efficiently.



